### PR TITLE
Add the ability to use simple string alerts

### DIFF
--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -10,9 +10,19 @@ class APNSPayload implements JsonSerializable {
 		$this->internal['alert'] = $alert;
 	}
 
-	function setAlert( APNSAlert $alert ) {
-		$this->internal['alert'] = $alert;
-		return $this;
+	function setAlert( $alert ) {
+
+		if ( is_string( $alert ) ) {
+			$this->internal['alert'] = $alert;
+			return $this;
+		}
+
+		if ( is_object( $alert ) && get_class( $alert ) === APNSAlert::class ) {
+			$this->internal['alert'] = $alert;
+			return $this;
+		}
+
+		throw new InvalidArgumentException( 'Invalid Alert – you must pass either a string or `APNSAlert` object.' );
 	}
 
 	function setBadgeCount( int $count ) {

--- a/tests/unit/APNSPayloadTest.php
+++ b/tests/unit/APNSPayloadTest.php
@@ -2,10 +2,21 @@
 declare( strict_types = 1 );
 class APNSPayloadTest extends APNSTest {
 
-	public function testThatAlertSetterWorks() {
+	public function testThatAlertSetterWorksForAlertObjects() {
 		$alert = $this->new_alert();
 		$push = $this->new_payload()->setAlert( $alert );
 		$this->assertEquals( $this->encode( $alert ), $this->encode( $push )->aps->alert );
+	}
+
+	public function testThatAlertSetterWorksForStrings() {
+		$alert = $this->random_string();
+		$push = $this->new_payload()->setAlert( $alert );
+		$this->assertEquals( $alert, $this->encode( $push )->aps->alert );
+	}
+
+	public function testThatAlertSetterThrowsForInvalidValues() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->new_payload()->setAlert( 0 );
 	}
 
 	public function testThatSoundIsNotPresentByDefault() {


### PR DESCRIPTION
Allows for:

```
{
    "aps" : { "alert" : "Message received from Bob" },
    "acme2" : [ "bang",  "whiz" ]
}
```

in addition to

```
{
    "aps" : {
        "alert" : {
            "title" : "Game Request",
            "body" : "Bob wants to play poker",
            "action-loc-key" : "PLAY"
        }
    },
    "acme2" : [ "bang",  "whiz" ]
}
```