### PR TITLE
Add non-composer autoloader

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types = 1 );
+
+// For use in non-composer environments
+
+require_once 'APNSClient.php';
+
+require_once 'model/APNSAlert.php';
+require_once 'model/APNSConfiguration.php';
+require_once 'model/APNSCredentials.php';
+require_once 'model/APNSPayload.php';
+require_once 'model/APNSPriority.php';
+require_once 'model/APNSPushType.php';
+require_once 'model/APNSRequest.php';
+require_once 'model/APNSRequestMetadata.php';
+require_once 'model/APNSResponse.php';
+require_once 'model/APNSResponseMetrics.php';
+require_once 'model/APNSSound.php';
+
+require_once 'helpers/HTTPMessageParser.php';
+
+require_once 'signing/APNSTokenFactory.php';
+require_once 'signing/APNSDefaultTokenFactory.php';


### PR DESCRIPTION
Allows single-statement `require` for all of this library's files.