### PR TITLE
Use absolute include paths

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit bootstrap="src/autoload.php">
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,9 @@
   <filter>
     <whitelist>
       <directory suffix=".php">src/</directory>
+      <exclude>
+        <file>src/autoload.php</file>
+      </exclude>
     </whitelist>
   </filter>
 </phpunit>

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -3,21 +3,21 @@ declare( strict_types = 1 );
 
 // For use in non-composer environments
 
-require_once 'APNSClient.php';
+require_once __DIR__ . '/APNSClient.php';
 
-require_once 'model/APNSAlert.php';
-require_once 'model/APNSConfiguration.php';
-require_once 'model/APNSCredentials.php';
-require_once 'model/APNSPayload.php';
-require_once 'model/APNSPriority.php';
-require_once 'model/APNSPushType.php';
-require_once 'model/APNSRequest.php';
-require_once 'model/APNSRequestMetadata.php';
-require_once 'model/APNSResponse.php';
-require_once 'model/APNSResponseMetrics.php';
-require_once 'model/APNSSound.php';
+require_once __DIR__ . '/model/APNSAlert.php';
+require_once __DIR__ . '/model/APNSConfiguration.php';
+require_once __DIR__ . '/model/APNSCredentials.php';
+require_once __DIR__ . '/model/APNSPayload.php';
+require_once __DIR__ . '/model/APNSPriority.php';
+require_once __DIR__ . '/model/APNSPushType.php';
+require_once __DIR__ . '/model/APNSRequest.php';
+require_once __DIR__ . '/model/APNSRequestMetadata.php';
+require_once __DIR__ . '/model/APNSResponse.php';
+require_once __DIR__ . '/model/APNSResponseMetrics.php';
+require_once __DIR__ . '/model/APNSSound.php';
 
-require_once 'helpers/HTTPMessageParser.php';
+require_once __DIR__ . '/helpers/HTTPMessageParser.php';
 
-require_once 'signing/APNSTokenFactory.php';
-require_once 'signing/APNSDefaultTokenFactory.php';
+require_once __DIR__ . '/signing/APNSTokenFactory.php';
+require_once __DIR__ . '/signing/APNSDefaultTokenFactory.php';


### PR DESCRIPTION
The WP.com linter doesn't like relative paths, so we'll fix it here.