### PR TITLE
Add request metadata tests

### DIFF
--- a/src/model/APNSPriority.php
+++ b/src/model/APNSPriority.php
@@ -4,4 +4,13 @@ declare( strict_types = 1 );
 class APNSPriority {
 	public const IMMEDIATE = 10;
 	public const THROTTLED = 5;
+
+	public static function isValid( int $key ): bool {
+		return in_array(
+			$key, [
+				APNSPriority::IMMEDIATE,
+				APNSPriority::THROTTLED,
+			], true
+		);
+	}
 }

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -40,13 +40,17 @@ abstract class APNSTest extends TestCase {
 		return new APNSAlert( $this->random_string(), $this->random_string() );
 	}
 
-	function new_metadata( ?string $topic = null ): APNSRequestMetadata {
+	function new_metadata( ?string $topic = null, ?string $uuid = null ): APNSRequestMetadata {
 
 		if ( is_null( $topic ) ) {
 			$topic = $this->random_string();
 		}
 
-		return new APNSRequestMetadata( $topic );
+		if ( is_null( $uuid ) ) {
+			$uuid = $this->random_uuid();
+		}
+
+		return new APNSRequestMetadata( $topic, $uuid );
 	}
 
 	function new_payload(): APNSPayload {
@@ -98,6 +102,10 @@ abstract class APNSTest extends TestCase {
 
 	function encode_to_array( $object ) {
 		return json_decode( json_encode( $object ), true );
+	}
+
+	function from_json( string $string ): object {
+		return json_decode( $string );
 	}
 
 	function replace_object_key_with_value( $object, $key, $value ) {

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -108,6 +108,18 @@ abstract class APNSTest extends TestCase {
 		return json_decode( $string );
 	}
 
+	function json_without( string $string, string $key ): string {
+		$object = json_decode( $string );
+		unset( $object->$key );
+		return json_encode( $object );
+	}
+
+	function json_adding( string $string, string $key, $value ): string {
+		$object = json_decode( $string );
+		$object->$key = $value;
+		return json_encode( $object );
+	}
+
 	function replace_object_key_with_value( $object, $key, $value ) {
 		$class = new ReflectionClass( get_class( $object ) );
 

--- a/tests/unit/APNSRequestMetadataTest.php
+++ b/tests/unit/APNSRequestMetadataTest.php
@@ -79,4 +79,59 @@ class APNSRequestMetadataTest extends APNSTest {
 		$meta = $this->new_metadata()->setUuid( $uuid );
 		$this->assertEquals( $uuid, $meta->getUuid() );
 	}
+
+	public function testThatMetadataSerializationIncludesTopic() {
+		$topic = $this->random_string();
+		$encoded = $this->from_json( $this->new_metadata( $topic )->toJSON() );
+		$this->assertEquals( $topic, $encoded->topic );
+	}
+
+	public function testThatMetadataSerializationIncludesUuid() {
+		$uuid = $this->random_string();
+		$encoded = $this->from_json( $this->new_metadata( $this->random_string(), $uuid )->toJSON() );
+		$this->assertEquals( $uuid, $encoded->uuid );
+	}
+
+	public function testThatMetadataSerializationDoesNotIncludePushTypeByDefault() {
+		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$this->assertFalse( property_exists( $encoded, 'push_type' ) );
+	}
+
+	public function testThatMetadataSerializationIncludesPushTypeIfSpecified() {
+		$push_type = APNSPushType::MDM;
+		$encoded = $this->from_json( $this->new_metadata()->setPushType( $push_type )->toJSON() );
+		$this->assertEquals( $push_type, $encoded->push_type );
+	}
+
+	public function testThatMetadataSerializationDoesNotIncludeExpirationTimestampByDefault() {
+		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$this->assertFalse( property_exists( $encoded, 'expiration_timestamp' ) );
+	}
+
+	public function testThatMetadataSerializationIncludesExpirationTimestampIfSpecified() {
+		$expires_at = random_int( 1, time() );
+		$encoded = $this->from_json( $this->new_metadata()->setExpirationTimestamp( $expires_at )->toJSON() );
+		$this->assertEquals( $expires_at, $encoded->expiration_timestamp );
+	}
+
+	public function testThatMetadataSerializationDoesNotIncludePriorityByDefault() {
+		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$this->assertFalse( property_exists( $encoded, 'priority' ) );
+	}
+
+	public function testThatMetadataSerializationIncludesPriorityIfSpecified() {
+		$encoded = $this->from_json( $this->new_metadata()->setLowPriority()->toJSON() );
+		$this->assertEquals( APNSPriority::THROTTLED, $encoded->priority );
+	}
+
+	public function testThatMetadataSerializationDoesNotIncludeCollapseIdentifierByDefault() {
+		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$this->assertFalse( property_exists( $encoded, 'collapse_identifier' ) );
+	}
+
+	public function testThatMetadataSerializationIncludesCollapseIdentifierIfSpecified() {
+		$identifier = $this->random_string();
+		$encoded = $this->from_json( $this->new_metadata()->setCollapseIdentifier( $identifier )->toJSON() );
+		$this->assertEquals( $identifier, $encoded->collapse_identifier );
+	}
 }

--- a/tests/unit/APNSRequestMetadataTest.php
+++ b/tests/unit/APNSRequestMetadataTest.php
@@ -134,4 +134,69 @@ class APNSRequestMetadataTest extends APNSTest {
 		$encoded = $this->from_json( $this->new_metadata()->setCollapseIdentifier( $identifier )->toJSON() );
 		$this->assertEquals( $identifier, $encoded->collapse_identifier );
 	}
+
+	public function testThatMetadataDeserializationIncludesTopic() {
+		$topic = $this->random_string();
+		$meta = APNSRequestMetadata::fromJSON( $this->new_metadata( $topic )->toJSON() );
+		$this->assertEquals( $topic, $meta->getTopic() );
+	}
+
+	public function testThatMetadataDeserializationIncludesUuid() {
+		$uuid = $this->random_uuid();
+		$meta = APNSRequestMetadata::fromJSON( $this->new_metadata( null, $uuid )->toJSON() );
+		$this->assertEquals( $uuid, $meta->getUuid() );
+	}
+
+	public function testThatMetadataDeserializationThrowsForMissingTopic() {
+		$json = $this->json_without( $this->new_metadata()->toJSON(), 'topic' );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequestMetadata::fromJSON( $json );
+	}
+
+	public function testThatMetadataDeserializationThrowsForMissingUuid() {
+		$json = $this->json_without( $this->new_metadata()->toJSON(), 'uuid' );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequestMetadata::fromJSON( $json );
+	}
+
+	public function testThatMetadataDeserializationIncludesPushTypeIfPresent() {
+		$push_type = APNSPushType::MDM;
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'push_type', $push_type );
+		$meta = APNSRequestMetadata::fromJSON( $json );
+		$this->assertEquals( $push_type, $meta->getPushType() );
+	}
+
+	public function testThatMetadataDeserializationIncludesExpirationTimestampIfPresent() {
+		$expiration_timestamp = time();
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'expiration_timestamp', $expiration_timestamp );
+		$meta = APNSRequestMetadata::fromJSON( $json );
+		$this->assertEquals( $expiration_timestamp, $meta->getExpirationTimestamp() );
+	}
+
+	public function testThatMetadataDeserializationIncludesLowPriorityIfPresent() {
+		$priority = APNSPriority::THROTTLED;
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', $priority );
+		$meta = APNSRequestMetadata::fromJSON( $json );
+		$this->assertEquals( $priority, $meta->getPriority() );
+	}
+
+	public function testThatMetadataDeserializationIncludesNormalPriorityIfPresent() {
+		$priority = APNSPriority::IMMEDIATE;
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', $priority );
+		$meta = APNSRequestMetadata::fromJSON( $json );
+		$this->assertEquals( $priority, $meta->getPriority() );
+	}
+
+	public function testThatMetadataDeserializationThrowsForInvalidPriority() {
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', 0 );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequestMetadata::fromJSON( $json );
+	}
+
+	public function testThatMetadataDeserializationIncludesCollapseIdentifierIfPresent() {
+		$collapse_identifier = $this->random_string();
+		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'collapse_identifier', $collapse_identifier );
+		$meta = APNSRequestMetadata::fromJSON( $json );
+		$this->assertEquals( $collapse_identifier, $meta->getCollapseIdentifier() );
+	}
 }


### PR DESCRIPTION
Improves test coverage for the `APNSRequestMetadata` class to ensure reliability around serialization and deserialization.