### PR TITLE
Add request tests

### DIFF
--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -13,7 +13,8 @@ class APNSRequest {
 	private $token;
 
 	static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
-		return new APNSRequest( $payload, $token, $metadata );
+		$payload = new APNSPayload( $payload );
+		return new APNSRequest( json_encode( $payload ), $token, $metadata );
 	}
 
 	static function fromPayload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -31,6 +31,10 @@ class APNSRequest {
 		return $this->token;
 	}
 
+	function getMetadata(): APNSRequestMetadata {
+		return $this->metadata;
+	}
+
 	function getBody(): string {
 		return $this->body;
 	}
@@ -89,8 +93,8 @@ class APNSRequest {
 		return json_encode(
 			[
 				'payload' => $this->body,
-				'metadata' => $this->metadata->toJSON(),
 				'token' => $this->token,
+				'metadata' => $this->metadata->toJSON(),
 			]
 		);
 	}
@@ -98,10 +102,18 @@ class APNSRequest {
 	public static function fromJSON( string $data ): self {
 		$object = json_decode( $data );
 
-		$payload = $object->payload;
-		$metadata = APNSRequestMetadata::fromJSON( $object->metadata );
-		$token = $object->token;
+		if ( ! property_exists( $object, 'payload' ) || is_null( $object->payload ) ) {
+			throw new InvalidArgumentException( 'Unable to unserialize object – `payload` is invalid' );
+		}
 
-		return new APNSRequest( $payload, $token, $metadata );
+		if ( ! property_exists( $object, 'token' ) || is_null( $object->token ) ) {
+			throw new InvalidArgumentException( 'Unable to unserialize object – `token` is invalid' );
+		}
+
+		if ( ! property_exists( $object, 'metadata' ) || is_null( $object->metadata ) ) {
+			throw new InvalidArgumentException( 'Unable to unserialize object – `metadata` is invalid' );
+		}
+
+		return new APNSRequest( $object->payload, $object->token, APNSRequestMetadata::fromJSON( $object->metadata ) );
 	}
 }

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -120,6 +120,10 @@ abstract class APNSTest extends TestCase {
 		return json_encode( $object );
 	}
 
+	function decode( string $string ): object {
+		return json_decode( $string );
+	}
+
 	function replace_object_key_with_value( $object, $key, $value ) {
 		$class = new ReflectionClass( get_class( $object ) );
 

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -40,6 +40,23 @@ abstract class APNSTest extends TestCase {
 		return new APNSAlert( $this->random_string(), $this->random_string() );
 	}
 
+	function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ) {
+
+		if ( is_null( $payload ) ) {
+			$payload = $this->new_payload();
+		}
+
+		if ( is_null( $token ) ) {
+			$token = $this->random_string();
+		}
+
+		if ( is_null( $metadata ) ) {
+			$metadata = $this->new_metadata();
+		}
+
+		return APNSRequest::fromPayload( $payload, $token, $metadata );
+	}
+
 	function new_metadata( ?string $topic = null, ?string $uuid = null ): APNSRequestMetadata {
 
 		if ( is_null( $topic ) ) {

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -57,6 +57,14 @@ abstract class APNSTest extends TestCase {
 		return APNSRequest::fromPayload( $payload, $token, $metadata );
 	}
 
+	function new_request_from_token( string $token ): APNSRequest {
+		return $this->new_request( null, $token, null );
+	}
+
+	function new_request_from_metadata( APNSRequestMetadata $meta ): APNSRequest {
+		return $this->new_request( null, null, $meta );
+	}
+
 	function new_metadata( ?string $topic = null, ?string $uuid = null ): APNSRequestMetadata {
 
 		if ( is_null( $topic ) ) {

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -2,7 +2,7 @@
 declare( strict_types = 1 );
 class APNSRequestTest extends APNSTest {
 
-	public function testRequestInstatiationFromString() {
+	public function testRequestInstantiationFromString() {
 		$message = $this->random_string();
 		$token = $this->random_string();
 

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -20,7 +20,7 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetBodyRetrievesJSONEncodedPush() {
 		$push = $this->new_payload();
-		$this->assertEquals( json_encode( $push ), $this->getRequest( $push )->getBody() );
+		$this->assertEquals( json_encode( $push ), $this->new_request( $push )->getBody() );
 	}
 
 	public function testThatGetUuidRetrievesUuid() {
@@ -34,7 +34,7 @@ class APNSRequestTest extends APNSTest {
 		$token = $this->random_string();
 		$configuration = $this->new_sandbox_configuration();
 
-		$req = $this->getRequest( $this->new_payload(), $token, $this->new_metadata() );
+		$req = $this->new_request( $this->new_payload(), $token, $this->new_metadata() );
 
 		$this->assertEquals( APNSConfiguration::APNS_ENDPOINT_SANDBOX . $token, $req->getUrlForConfiguration( $configuration ) );
 	}
@@ -43,7 +43,7 @@ class APNSRequestTest extends APNSTest {
 		$token = $this->random_string();
 		$configuration = $this->new_configuration_with_mocked_provider_token( $token );
 
-		$headers = $this->getRequest( $this->new_payload(), $token, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), $token, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'authorization', $headers );
 		$this->assertEquals( 'bearer ' . $token, $headers['authorization'] );
@@ -52,7 +52,7 @@ class APNSRequestTest extends APNSTest {
 	public function testThatGetHeadersContainsContentType() {
 		$configuration = $this->new_configuration();
 
-		$headers = $this->getRequest( $this->new_payload() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload() )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'content-type', $headers );
 		$this->assertEquals( 'application/json', $headers['content-type'] );
@@ -62,7 +62,7 @@ class APNSRequestTest extends APNSTest {
 		$push = $this->new_payload();
 		$configuration = $this->new_configuration();
 
-		$headers = $this->getRequest( $push )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $push )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'content-length', $headers );
 		$this->assertEquals( strlen( json_encode( $push ) ), $headers['content-length'] );
@@ -73,7 +73,7 @@ class APNSRequestTest extends APNSTest {
 		$expiration = time() + 60;
 		$meta = $this->new_metadata()->setExpirationTimestamp( $expiration );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-expiration', $headers );
 		$this->assertEquals( $expiration, $headers['apns-expiration'] );
@@ -84,7 +84,7 @@ class APNSRequestTest extends APNSTest {
 		$push_type = APNSPushType::MDM;
 		$meta = $this->new_metadata()->setPushType( $push_type );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-push-type', $headers );
 		$this->assertEquals( $push_type, $headers['apns-push-type'] );
@@ -95,7 +95,7 @@ class APNSRequestTest extends APNSTest {
 		$topic = $this->random_string();
 		$meta = $this->new_metadata()->setTopic( $topic );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-topic', $headers );
 		$this->assertEquals( $topic, $headers['apns-topic'] );
@@ -103,14 +103,14 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainUserAgentByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'user-agent', $this->getRequest()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'user-agent', $this->new_request()->getHeadersForConfiguration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsUserAgentIfSet() {
 		$ua = $this->random_string();
 		$configuration = $this->new_configuration()->setUserAgent( $ua );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'user-agent', $headers );
 		$this->assertEquals( $ua, $headers['user-agent'] );
@@ -118,14 +118,14 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainPriorityByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'apns-priority', $this->getRequest()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'apns-priority', $this->new_request()->getHeadersForConfiguration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsPriorityIfSet() {
 		$configuration = $this->new_configuration();
 		$meta = $this->new_metadata()->setLowPriority();
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-priority', $headers );
 		$this->assertEquals( 5, $headers['apns-priority'] );
@@ -133,7 +133,7 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersAlwaysContainApnsIdByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayHasKey( 'apns-id', $this->getRequest()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayHasKey( 'apns-id', $this->new_request()->getHeadersForConfiguration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsApnsIdIfSet() {
@@ -141,7 +141,7 @@ class APNSRequestTest extends APNSTest {
 		$uuid = $this->random_uuid();
 		$meta = $this->new_metadata()->setUuid( $uuid );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-id', $headers );
 		$this->assertEquals( $uuid, $headers['apns-id'] );
@@ -149,7 +149,7 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainCollapseIdByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'apns-collapse-id', $this->getRequest()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'apns-collapse-id', $this->new_request()->getHeadersForConfiguration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsCollapseIdIfSet() {
@@ -157,26 +157,9 @@ class APNSRequestTest extends APNSTest {
 		$id = $this->random_string();
 		$meta = $this->new_metadata()->setCollapseIdentifier( $id );
 
-		$headers = $this->getRequest( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-collapse-id', $headers );
 		$this->assertEquals( $id, $headers['apns-collapse-id'] );
-	}
-
-	private function getRequest( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ) {
-
-		if ( is_null( $payload ) ) {
-			$payload = $this->new_payload();
-		}
-
-		if ( is_null( $token ) ) {
-			$token = $this->random_string();
-		}
-
-		if ( is_null( $metadata ) ) {
-			$metadata = $this->new_metadata();
-		}
-
-		return APNSRequest::fromPayload( $payload, $token, $metadata );
 	}
 }

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -2,9 +2,32 @@
 declare( strict_types = 1 );
 class APNSRequestTest extends APNSTest {
 
+	public function testRequestInstatiationFromString() {
+		$message = $this->random_string();
+		$token = $this->random_string();
+
+		$request = APNSRequest::fromString( $message, $token, $this->new_metadata() );
+		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
+	}
+
+	public function testThatGetTokenRetrievesToken() {
+		$message = $this->random_string();
+		$token = $this->random_string();
+
+		$request = APNSRequest::fromString( $message, $token, $this->new_metadata() );
+		$this->assertEquals( $token, $request->getToken() );
+	}
+
 	public function testThatGetBodyRetrievesJSONEncodedPush() {
 		$push = $this->new_payload();
 		$this->assertEquals( json_encode( $push ), $this->getRequest( $push )->getBody() );
+	}
+
+	public function testThatGetUuidRetrievesUuid() {
+		$uuid = $this->random_uuid();
+
+		$request = APNSRequest::fromString( '', '', $this->new_metadata( null, $uuid ) );
+		$this->assertEquals( $uuid, $request->getUuid() );
 	}
 
 	public function testThatGetUrlForTokenRetrievesValidValue() {

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -162,4 +162,24 @@ class APNSRequestTest extends APNSTest {
 		$this->assertArrayHasKey( 'apns-collapse-id', $headers );
 		$this->assertEquals( $id, $headers['apns-collapse-id'] );
 	}
+
+	public function testThatRequestSerializationIncludesPayload() {
+		$payload = $this->new_payload();
+		$request = $this->decode( $this->new_request( $payload )->toJSON() );
+
+		$this->assertEquals( json_encode( $payload ), $request->payload );
+	}
+
+	public function testThatRequestSerializationIncludesMetadata() {
+		$metadata = $this->new_metadata();
+		$request = $this->decode( $this->new_request_from_metadata( $metadata )->toJSON() );
+
+		$this->assertEquals( $metadata->toJSON(), $request->metadata );
+	}
+
+	public function testThatRequestSerializationIncludesToken() {
+		$token = $this->random_string();
+		$request = $this->new_request_from_token( $token );
+		$this->assertEquals( $token, $request->getToken() );
+	}
 }

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -182,4 +182,40 @@ class APNSRequestTest extends APNSTest {
 		$request = $this->new_request_from_token( $token );
 		$this->assertEquals( $token, $request->getToken() );
 	}
+
+	public function testThatRequestDeserializationIncludesPayload() {
+		$payload = $this->new_payload();
+		$request = APNSRequest::fromJSON( $this->new_request( $payload )->toJSON() );
+		$this->assertEquals( json_encode( $payload ), $request->getBody() );
+	}
+
+	public function testThatRequestDeserializationIncludesToken() {
+		$token = $this->random_string();
+		$request = APNSRequest::fromJSON( $this->new_request_from_token( $token )->toJSON() );
+		$this->assertEquals( $token, $request->getToken() );
+	}
+
+	public function testThatRequestDeserializationIncludesMetadata() {
+		$meta = $this->new_metadata();
+		$request = APNSRequest::fromJSON( $this->new_request_from_metadata( $meta )->toJSON() );
+		$this->assertEquals( $meta, $request->getMetadata() );
+	}
+
+	public function testThatRequestDeserializationThrowsForMissingPayload() {
+		$json = $this->json_without( $this->new_request()->toJSON(), 'payload' );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequest::fromJSON( $json );
+	}
+
+	public function testThatRequestDeserializationThrowsForMissingToken() {
+		$json = $this->json_without( $this->new_request()->toJSON(), 'token' );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequest::fromJSON( $json );
+	}
+
+	public function testThatRequestDeserializationThrowsForMissingMetadata() {
+		$json = $this->json_without( $this->new_request()->toJSON(), 'metadata' );
+		$this->expectException( InvalidArgumentException::class );
+		APNSRequest::fromJSON( $json );
+	}
 }


### PR DESCRIPTION
Improves test coverage for the `APNSRequest` class to ensure reliability around serialization and deserialization.

This PR depends on (and currently contains) #23 and should be rebased on `main` before reviewing it
