### PR TITLE
Load Dotenv in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,10 +3,9 @@ declare( strict_types = 1 );
 
 require_once __DIR__ . '/vendor/autoload.php' );
 
-use Dotenv\Dotenv as Dotenv;
+use Dotenv\Dotenv;
 
-$dotenv = Dotenv::createImmutable( __DIR__ );
-$dotenv->load();
+Dotenv::createImmutable( __DIR__ )->load();
 
 echo '=== Push Notification Server ===' . PHP_EOL;
 

--- a/index.php
+++ b/index.php
@@ -3,6 +3,11 @@ declare( strict_types = 1 );
 
 require_once __DIR__ . '/vendor/autoload.php' );
 
+use Dotenv\Dotenv as Dotenv;
+
+$dotenv = Dotenv::createImmutable( __DIR__ );
+$dotenv->load();
+
 echo '=== Push Notification Server ===' . PHP_EOL;
 
 // var_dump(getenv('USER_AGENT'));


### PR DESCRIPTION
I'm not sure whether this is required or there's something missing in my setup.

Even after creating `.env` locally, `php index.php` failed saying that the init parameters for `APNSConfiguration` were booleans instead of strings, that is, the environment variables couldn't be found.

Explicitly loading dotenv [as per the documentation](https://github.com/vlucas/phpdotenv/tree/c2da5440047bbaf8ed8dc29a0df300e88b5cb50b#usage) solved the problem for me.