### PR TITLE
Add examples folder to list of folders to lint and fix issues

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,6 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
 	<file>src</file>
 	<file>tests</file>
+	<file>examples</file>
 	<file>index.php</file>
 
  	<rule ref="NeutronRuleset"/>

--- a/examples/add-to-queue.php
+++ b/examples/add-to-queue.php
@@ -1,19 +1,19 @@
-<?php 
+<?php
+declare( strict_types = 1 );
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/db-connect.php';
 
 global $capsule;
 
-
-while(true) {
+while ( true ) {
 	$notifications = [];
 
-	for($i = 0; $i < random_int(2,15); $i++) {
-		$message = bin2hex(random_bytes(random_int(2, 2048)));
-		$alert = new APNSAlert('Title', $message);
-		savePush(new APNSPush($alert, getenv('TOPIC')), getenv('TOKEN'));
+	for ( $i = 0; $i < random_int( 2, 15 ); $i++ ) {
+		$message = bin2hex( random_bytes( random_int( 2, 2048 ) ) );
+		$alert = new APNSAlert( 'Title', $message );
+		savePush( new APNSPush( $alert, getenv( 'TOPIC' ) ), getenv( 'TOKEN' ) );
 	}
 
-	sleep(1);
+	sleep( 1 );
 }

--- a/examples/db-connect.php
+++ b/examples/db-connect.php
@@ -1,37 +1,46 @@
 <?php
+declare( strict_types = 1 );
 
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
+use Dotenv\Dotenv;
+
+$dotenv = Dotenv\Dotenv::createImmutable( dirname( __DIR__ ) );
 $dotenv->load();
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 
 $capsule = new Capsule;
-$capsule->addConnection([
-    'driver'    => 'mysql',
-    'host'      => 'localhost',
-    'database'  => getenv('DATABASE'),
-    'username'  => getenv('USERNAME'),
-    'password'  => getenv('PASSWORD'),
-    'charset'   => 'utf8',
-    'collation' => 'utf8_unicode_ci',
-    'prefix'    => '',
-]);
+$capsule->addConnection(
+	[
+		'driver' => 'mysql',
+		'host' => 'localhost',
+		'database' => getenv( 'DATABASE' ),
+		'username' => getenv( 'USERNAME' ),
+		'password' => getenv( 'PASSWORD' ),
+		'charset' => 'utf8',
+		'collation' => 'utf8_unicode_ci',
+		'prefix' => '',
+	]
+);
 
 // Make this Capsule instance available globally via static methods... (optional)
 $capsule->setAsGlobal();
 
-function savePush(APNSPush $push, $token) {
+// phpcs:ignore NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions,WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function savePush( APNSPush $push, $token ) {
 	global $capsule;
 
-	$capsule->table('mobile_push_queue')->insert([
-		'token'					=> $token,
-		'payload'				=> json_encode($push),
-		'when'					=> date("Y-m-d H:i:s"),
-		'mobile_push_client_id'	=> 0,
-	]);
+	$capsule->table( 'mobile_push_queue' )->insert(
+		[
+			'token' => $token,
+			'payload' => json_encode( $push ),
+			'when' => gmdate( 'Y-m-d H:i:s' ),
+			'mobile_push_client_id' => 0,
+		]
+	);
 }
 
-function getPushes($count = 10) {
+// phpcs:ignore NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions,WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function getPushes( $count = 10 ) {
 	global $capsule;
-	return $capsule->table('mobile_push_queue')->limit($count)->get();
+	return $capsule->table( 'mobile_push_queue' )->limit( $count )->get();
 }

--- a/examples/run-queue.php
+++ b/examples/run-queue.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/db-connect.php';
@@ -7,32 +8,30 @@ global $capsule;
 
 echo '=== Push Notification Server ===' . PHP_EOL;
 
-$kid = getenv('KEY_ID');
-$tid = getenv('TEAM_ID');
-$key = getenv('KEY');
+$kid = getenv( 'KEY_ID' );
+$tid = getenv( 'TEAM_ID' );
+$key = getenv( 'KEY' );
 
-$auth = new APNSCredentials($kid, $tid, $key);
-$configuration = APNSConfiguration::production($auth);
-$configuration->setUserAgent('wordpress.com development');
+$auth = new APNSCredentials( $kid, $tid, $key );
+$configuration = APNSConfiguration::production( $auth );
+$configuration->setUserAgent( 'wordpress.com development' );
 
 $client = new APNSClient( $configuration );
 
 echo "\t Connected.\n";
 
-while(true) {
-	$start = microtime(true);
+while ( true ) {
+	$start = microtime( true );
 
 	$pushes = getPushes();
 
-	$time = microtime(true) - $start;
-	echo PHP_EOL . '=== Fetched ' . count($pushes) . ' Messages in ' . $time . ' seconds === ' . PHP_EOL;
+	$time = microtime( true ) - $start;
+	echo PHP_EOL . '=== Fetched ' . count( $pushes ) . ' Messages in ' . $time . ' seconds === ' . PHP_EOL;
 
-	$client->sendPayloads($pushes->all());
+	$client->sendPayloads( $pushes->all() );
 
-	$time = microtime(true) - $start;
+	$time = microtime( true ) - $start;
 	echo PHP_EOL . '=== Done in ' . $time . ' seconds === ' . PHP_EOL;
 }
-
-
 
 $client->close();

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types = 1 );
 
-require_once __DIR__ . '/vendor/autoload.php' );
+require_once __DIR__ . '/vendor/autoload.php';
 
 echo '=== Push Notification Server ===' . PHP_EOL;
 


### PR DESCRIPTION
Most of the changes were made by `phpcbf`.

I'm not sure about the change from `date` to `gmdate`, the rationale provided by PHPCS was:

> date() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.

I suppose it's a safe change to make, given this is only an example file anyways.

I decided to disable the warnings on global functions and function name not using snake casing for the same reason as above, this is an example file.