### PR TITLE
Add example improvements

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,7 +2,11 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
 	<file>src</file>
 	<file>tests</file>
+	<file>examples</file>
 	<file>index.php</file>
 
- 	<rule ref="NeutronRuleset"/>
+	<rule ref="NeutronRuleset"/>
+	<rule ref="NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions">
+		<exclude-pattern>/examples/db-connect\.php</exclude-pattern>
+	</rule>
 </ruleset>

--- a/examples/add-to-queue.php
+++ b/examples/add-to-queue.php
@@ -9,11 +9,15 @@ global $capsule;
 while(true) {
 	$notifications = [];
 
-	for($i = 0; $i < random_int(2,15); $i++) {
+	$token = bin2hex(random_bytes(32));
+	saveToken($token);
+
+	for($i = 0; $i < 2; $i++) {
 		$message = bin2hex(random_bytes(random_int(2, 2048)));
 		$alert = new APNSAlert('Title', $message);
-		savePush(new APNSPush($alert, getenv('TOPIC')), getenv('TOKEN'));
-	}
+		$payload = new APNSPayload($alert);
 
-	sleep(1);
+		$request = APNSRequest::fromPayload($payload, $token, new APNSRequestMetadata(getenv('topic')));
+		savePush($request);
+	}
 }

--- a/examples/add-to-queue.php
+++ b/examples/add-to-queue.php
@@ -1,23 +1,23 @@
-<?php 
+<?php
+declare( strict_types = 1 );
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/db-connect.php';
 
-global $capsule;
+$topic = (string) getenv( 'topic' );
 
-
-while(true) {
+while ( true ) {
 	$notifications = [];
 
-	$token = bin2hex(random_bytes(32));
-	saveToken($token);
+	$token = bin2hex( random_bytes( 32 ) );
+	save_token( $token );
 
-	for($i = 0; $i < 2; $i++) {
-		$message = bin2hex(random_bytes(random_int(2, 2048)));
-		$alert = new APNSAlert('Title', $message);
-		$payload = new APNSPayload($alert);
+	for ( $i = 0; $i < 2; $i++ ) {
+		$message = bin2hex( random_bytes( random_int( 2, 2048 ) ) );
+		$alert = new APNSAlert( 'Title', $message );
+		$payload = new APNSPayload( $alert );
 
-		$request = APNSRequest::fromPayload($payload, $token, new APNSRequestMetadata(getenv('topic')));
-		savePush($request);
+		$request = APNSRequest::fromPayload( $payload, $token, new APNSRequestMetadata( $topic ) );
+		save_request( $request );
 	}
 }

--- a/examples/db-connect.php
+++ b/examples/db-connect.php
@@ -10,8 +10,8 @@ $capsule->addConnection([
     'driver'    => 'mysql',
     'host'      => 'localhost',
     'database'  => getenv('DATABASE'),
-    'username'  => getenv('USERNAME'),
-    'password'  => getenv('PASSWORD'),
+    'username'  => getenv('DB_USERNAME'),
+    'password'  => getenv('DB_PASSWORD'),
     'charset'   => 'utf8',
     'collation' => 'utf8_unicode_ci',
     'prefix'    => '',
@@ -20,18 +20,38 @@ $capsule->addConnection([
 // Make this Capsule instance available globally via static methods... (optional)
 $capsule->setAsGlobal();
 
-function savePush(APNSPush $push, $token) {
+function savePush(APNSRequest $request) {
 	global $capsule;
 
 	$capsule->table('mobile_push_queue')->insert([
-		'token'					=> $token,
-		'payload'				=> json_encode($push),
+		'token'					=> $request->getToken(),
+		'payload'				=> $request->toJSON(),
 		'when'					=> date("Y-m-d H:i:s"),
-		'mobile_push_client_id'	=> 0,
+		'mobile_push_client_id'	=> getClientId(),
+		'worker_id'				=> random_int(1,16)
 	]);
 }
 
 function getPushes($count = 10) {
 	global $capsule;
 	return $capsule->table('mobile_push_queue')->limit($count)->get();
+}
+
+function saveToken(string $token) {
+	global $capsule;
+
+	$capsule->table('mobile_push_tokens')->insert([
+		'token'					=> $token,
+		'user_id'				=> random_int(1, pow(2,31)),
+		'when'					=> date("Y-m-d H:i:s"),
+		'active'				=> 1,
+		'device_type'			=> ['apple', 'android'][random_int(0,1)],
+		'production'			=> random_int(0,1),
+		'meta'					=> '',
+		'mobile_push_client_id'	=> getClientId()
+	]);
+}
+
+function getClientId() {
+	return random_int(0, 10);
 }

--- a/examples/db-connect.php
+++ b/examples/db-connect.php
@@ -1,57 +1,65 @@
 <?php
-
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
-$dotenv->load();
+declare( strict_types = 1 );
 
 use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Collection;
+use Dotenv\Dotenv;
+
+Dotenv::createImmutable( dirname( __DIR__ ) )->load();
 
 $capsule = new Capsule;
-$capsule->addConnection([
-    'driver'    => 'mysql',
-    'host'      => 'localhost',
-    'database'  => getenv('DATABASE'),
-    'username'  => getenv('DB_USERNAME'),
-    'password'  => getenv('DB_PASSWORD'),
-    'charset'   => 'utf8',
-    'collation' => 'utf8_unicode_ci',
-    'prefix'    => '',
-]);
+$capsule->addConnection(
+	[
+		'driver' => 'mysql',
+		'host' => 'localhost',
+		'database' => getenv( 'DATABASE' ),
+		'username' => getenv( 'DB_USERNAME' ),
+		'password' => getenv( 'DB_PASSWORD' ),
+		'charset' => 'utf8',
+		'collation' => 'utf8_unicode_ci',
+		'prefix' => '',
+	]
+);
 
 // Make this Capsule instance available globally via static methods... (optional)
 $capsule->setAsGlobal();
 
-function savePush(APNSRequest $request) {
+function save_request( APNSRequest $request ): void {
 	global $capsule;
 
-	$capsule->table('mobile_push_queue')->insert([
-		'token'					=> $request->getToken(),
-		'payload'				=> $request->toJSON(),
-		'when'					=> date("Y-m-d H:i:s"),
-		'mobile_push_client_id'	=> getClientId(),
-		'worker_id'				=> random_int(1,16)
-	]);
+	$capsule->table( 'mobile_push_queue' )->insert(
+		[
+			'token' => $request->getToken(),
+			'payload' => $request->toJSON(),
+			'when' => gmdate( 'Y-m-d H:i:s' ),
+			'mobile_push_client_id' => get_client_id(),
+			'worker_id' => random_int( 1, 16 ),
+		]
+	);
 }
 
-function getPushes($count = 10) {
+function get_request( int $count = 10 ): Collection {
 	global $capsule;
-	return $capsule->table('mobile_push_queue')->limit($count)->get();
+	return $capsule->table( 'mobile_push_queue' )->limit( $count )->get();
 }
 
-function saveToken(string $token) {
+function save_token( string $token ): void {
 	global $capsule;
 
-	$capsule->table('mobile_push_tokens')->insert([
-		'token'					=> $token,
-		'user_id'				=> random_int(1, pow(2,31)),
-		'when'					=> date("Y-m-d H:i:s"),
-		'active'				=> 1,
-		'device_type'			=> ['apple', 'android'][random_int(0,1)],
-		'production'			=> random_int(0,1),
-		'meta'					=> '',
-		'mobile_push_client_id'	=> getClientId()
-	]);
+	$capsule->table( 'mobile_push_tokens' )->insert(
+		[
+			'token' => $token,
+			'user_id' => random_int( 1, 2147483647 ),
+			'when' => gmdate( 'Y-m-d H:i:s' ),
+			'active' => 1,
+			'device_type' => [ 'apple', 'android' ][ random_int( 0, 1 ) ],
+			'production' => random_int( 0, 1 ),
+			'meta' => '',
+			'mobile_push_client_id' => get_client_id(),
+		]
+	);
 }
 
-function getClientId() {
-	return random_int(0, 10);
+function get_client_id(): int {
+	return random_int( 0, 10 );
 }

--- a/examples/run-queue.php
+++ b/examples/run-queue.php
@@ -1,38 +1,35 @@
 <?php
+declare( strict_types = 1 );
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/db-connect.php';
 
-global $capsule;
-
 echo '=== Push Notification Server ===' . PHP_EOL;
 
-$kid = getenv('KEY_ID');
-$tid = getenv('TEAM_ID');
-$key = getenv('KEY');
+$kid = strval( getenv( 'KEY_ID' ) );
+$tid = strval( getenv( 'TEAM_ID' ) );
+$key = strval( getenv( 'KEY' ) );
 
-$auth = new APNSCredentials($kid, $tid, $key);
-$configuration = APNSConfiguration::production($auth);
-$configuration->setUserAgent('wordpress.com development');
+$auth = new APNSCredentials( $kid, $tid, $key );
+$configuration = APNSConfiguration::production( $auth );
+$configuration->setUserAgent( 'wordpress.com development' );
 
 $client = new APNSClient( $configuration );
 
 echo "\t Connected.\n";
 
-while(true) {
-	$start = microtime(true);
+while ( true ) {
+	$start = microtime( true );
 
-	$pushes = getPushes();
+	$pushes = get_request();
 
-	$time = microtime(true) - $start;
-	echo PHP_EOL . '=== Fetched ' . count($pushes) . ' Messages in ' . $time . ' seconds === ' . PHP_EOL;
+	$time = microtime( true ) - $start;
+	echo PHP_EOL . '=== Fetched ' . count( $pushes ) . ' Messages in ' . $time . ' seconds === ' . PHP_EOL;
 
-	$client->sendPayloads($pushes->all());
+	$client->sendRequests( $pushes->all() );
 
-	$time = microtime(true) - $start;
+	$time = microtime( true ) - $start;
 	echo PHP_EOL . '=== Done in ' . $time . ' seconds === ' . PHP_EOL;
 }
-
-
 
 $client->close();

--- a/index.php
+++ b/index.php
@@ -36,7 +36,6 @@ foreach ( range( 0, 2 ) as $i ) {
 $responses = $client->sendRequests( $requests );
 
 $notifications_to_retry = [];
-$notifications_to_delete = [];
 $tokens_to_delete = [];
 
 foreach ( $responses as $response ) {
@@ -44,9 +43,7 @@ foreach ( $responses as $response ) {
 		$notifications_to_delete[] = $response->getUuid();
 	} elseif ( $response->shouldRetry() ) {
 		$notifications_to_retry[] = $response->getUuid();
-	}// elseif ( $response->shouldUnsubscribeDevice() ) {
-	//	$tokens_to_delete[] = $response->getToken();
-	//}
+	}
 }
 
 echo '=== Requests to Delete ===' . PHP_EOL;
@@ -57,11 +54,6 @@ foreach ( $notifications_to_delete as $uuid ) {
 echo '=== Requests to Retry ===' . PHP_EOL;
 foreach ( $notifications_to_retry as $uuid ) {
 	echo "\t$uuid" . PHP_EOL;
-}
-
-echo '=== Tokens to Delete ===' . PHP_EOL;
-foreach ( $tokens_to_delete as $token ) {
-	echo "\t$token" . PHP_EOL;
 }
 
 $client->close();

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types = 1 );
 
-require_once __DIR__ . '/vendor/autoload.php' );
+require_once __DIR__ . '/vendor/autoload.php';
 
 use Dotenv\Dotenv;
 
@@ -9,10 +9,11 @@ Dotenv::createImmutable( __DIR__ )->load();
 
 echo '=== Push Notification Server ===' . PHP_EOL;
 
-// var_dump(getenv('USER_AGENT'));
-// die();
+$key_id = strval( getenv( 'KEY_ID' ) );
+$team_id = strval( getenv( 'TEAM_ID' ) );
+$key = strval( getenv( 'KEY' ) );
 
-$auth = new APNSCredentials( getenv( 'KEY_ID' ), getenv( 'TEAM_ID' ), getenv( 'KEY' ) );
+$auth = new APNSCredentials( $key_id, $team_id, $key );
 $configuration = APNSConfiguration::production( $auth );
 // $configuration->setUserAgent( getenv( 'USER_AGENT' ) );
 $client = new APNSClient( $configuration );
@@ -20,7 +21,7 @@ $client = new APNSClient( $configuration );
 
 echo "\t Connected.\n";
 
-$token = getenv( 'TOKEN' );
+$token = strval( getenv( 'TOKEN' ) );
 $payload = new APNSPayload( new APNSAlert( 'Title', 'Message' ) );
 $metadata = new APNSRequestMetadata( 'org.WordPress' );
 $request = APNSRequest::fromPayload( $payload, $token, $metadata );
@@ -43,9 +44,9 @@ foreach ( $responses as $response ) {
 		$notifications_to_delete[] = $response->getUuid();
 	} elseif ( $response->shouldRetry() ) {
 		$notifications_to_retry[] = $response->getUuid();
-	} elseif ( $response->shouldUnsubscribeDevice() ) {
-		$tokens_to_delete[] = $response->getToken();
-	}
+	}// elseif ( $response->shouldUnsubscribeDevice() ) {
+	//	$tokens_to_delete[] = $response->getToken();
+	//}
 }
 
 echo '=== Requests to Delete ===' . PHP_EOL;

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,8 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="examples" />
+        <file name="index.php" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>


### PR DESCRIPTION
This PR fixes a few issues with the examples directory (which prior to this was getting pretty out of date).

- The examples used old class names that are no longer part of the project – these have been updated.
- Psalm is now used for `examples/` and `index.php`. This helps validate correctness - which will catch things like the out-of-place extra `)` character.
- PHPCS is now used for `examples/`. This helps ensure that we won't run into linter issues on WordPress.com.