### PR TITLE
Add convenience initializers

### DIFF
--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -19,6 +19,10 @@ class APNSClient {
 		$this->refreshToken();
 	}
 
+	public static function withConfiguration( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ): self {
+		return new APNSClient( $configuration, $network_service );
+	}
+
 	public function setPortNumber( int $port ): void {
 		$this->network_service->setPort( $port );
 	}

--- a/src/model/APNSRequestMetadata.php
+++ b/src/model/APNSRequestMetadata.php
@@ -26,6 +26,10 @@ class APNSRequestMetadata {
 		$this->uuid = $uuid ?? $this->generate_uuid();
 	}
 
+	public static function withTopic( string $topic ): self {
+		return new APNSRequestMetadata( $topic );
+	}
+
 	function getTopic(): string {
 		return $this->topic;
 	}

--- a/tests/unit/APNSClientTest.php
+++ b/tests/unit/APNSClientTest.php
@@ -15,7 +15,7 @@ class APNSClientTest extends APNSTest {
 		$network_service_mock
 			->shouldReceive( 'sendQueuedRequests' )
 			->andReturn( $fake_responses );
-		$client = new APNSClient( $this->new_configuration(), $network_service_mock );
+		$client = APNSClient::withConfiguration( $this->new_configuration(), $network_service_mock );
 
 		$responses = $client->sendRequests( [ $this->new_request() ] );
 

--- a/tests/unit/APNSCredentialsTest.php
+++ b/tests/unit/APNSCredentialsTest.php
@@ -2,7 +2,7 @@
 declare( strict_types = 1 );
 class APNSCredentialsTest extends APNSTest {
 
-	public function testThatAPNSCredentialInstantationProperlyStoresValues() {
+	public function testThatAPNSCredentialInstantiationProperlyStoresValues() {
 		$key_id = $this->random_string( 10 );
 		$team_id = $this->random_string( 10 );
 		$key_bytes = random_bytes( 32 );

--- a/tests/unit/APNSRequestMetadataTest.php
+++ b/tests/unit/APNSRequestMetadataTest.php
@@ -8,6 +8,11 @@ class APNSRequestMetadataTest extends APNSTest {
 		$this->assertEquals( $topic, $meta->getTopic() );
 	}
 
+	public function testThatConvenienceInitializerStoresTopic() {
+		$topic = $this->random_string();
+		$this->assertEquals( $topic, APNSRequestMetadata::withTopic( $topic )->getTopic() );
+	}
+
 	public function testThatTopicSetterWorks() {
 		$topic = $this->random_string();
 		$meta = $this->new_metadata()->setTopic( $topic );


### PR DESCRIPTION
This PR is waiting on #32 – it can be merged after that (because I'll add a couple of quick initializer tests)

Added to:
- APNSClient
- APNSRequestMetadata

This allows:

```
APNSClient::withConfiguration($configuration)->setDebug(true);
```

instead of:

```
(new APNSClient($configuration))->setDebug(true);
```