### PR TITLE
Fix inconsistency issues

### DIFF
--- a/src/model/APNSConfiguration.php
+++ b/src/model/APNSConfiguration.php
@@ -101,7 +101,7 @@ class APNSConfiguration {
 		return $this;
 	}
 
-	function get_endpoint(): string {
+	function getEndpoint(): string {
 		if ( $this->environment === APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION ) {
 			return APNSConfiguration::APNS_ENDPOINT_PRODUCTION;
 		}

--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -2,7 +2,7 @@
 declare( strict_types = 1 );
 
 // Partial list of keys: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363
-class APNSPayload implements JsonSerializable {
+class APNSPayload {
 
 	/** @var string|APNSAlert */
 	private $alert = '';
@@ -117,23 +117,25 @@ class APNSPayload implements JsonSerializable {
 		return $this;
 	}
 
-	public function jsonSerialize() {
-		return array_merge(
-			$this->custom,
-			[
-				'aps' => (object) array_filter(
-					[
-						'alert' => $this->alert,
-						'badge' => $this->badge,
-						'sound' => $this->sound,
-						'content-available' => $this->content_available,
-						'mutable-content' => $this->mutable_content,
-						'target-content-id' => $this->target_content_id,
-						'category' => $this->category,
-						'thread-id' => $this->thread_id,
-					], function( $value ) { return ! is_null( $value ); }
-				),
-			]
+	public function toJSON(): string {
+		return json_encode(
+			array_merge(
+				$this->custom,
+				[
+					'aps' => (object) array_filter(
+						[
+							'alert' => $this->alert,
+							'badge' => $this->badge,
+							'sound' => $this->sound,
+							'content-available' => $this->content_available,
+							'mutable-content' => $this->mutable_content,
+							'target-content-id' => $this->target_content_id,
+							'category' => $this->category,
+							'thread-id' => $this->thread_id,
+						], function( $value ) { return ! is_null( $value ); }
+					),
+				]
+			)
 		);
 	}
 }

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -44,7 +44,7 @@ class APNSRequest {
 	}
 
 	function getUrlForConfiguration( APNSConfiguration $configuration ): string {
-		return $configuration->get_endpoint() . $this->token;
+		return $configuration->getEndpoint() . $this->token;
 	}
 
 	/**

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -14,11 +14,11 @@ class APNSRequest {
 
 	static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
 		$payload = new APNSPayload( $payload );
-		return new APNSRequest( json_encode( $payload ), $token, $metadata );
+		return new APNSRequest( $payload->toJSON(), $token, $metadata );
 	}
 
 	static function fromPayload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
-		return new APNSRequest( json_encode( $payload ), $token, $metadata );
+		return new APNSRequest( $payload->toJSON(), $token, $metadata );
 	}
 
 	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata ) {

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -9,7 +9,7 @@ abstract class APNSTest extends TestCase {
 
 	protected function assertKeyIsNotPresentForObject( $key, object $object ) {
 		$this->assertNotNull( $object );
-		$object = $this->encode( $object );
+		$object = $this->to_stdclass( $object );
 		$this->assertFalse( property_exists( $object, $key ) );
 	}
 
@@ -121,12 +121,11 @@ abstract class APNSTest extends TestCase {
 		return new APNSCredentials( $this->random_string( 10 ), $this->random_string( 10 ), '' );
 	}
 
-	function encode( $object ) {
+	function to_stdclass( $object ): object {
+		if ( is_a( $object, APNSPayload::class ) ) {
+			return $this->from_json( $object->toJSON() );
+		}
 		return json_decode( json_encode( $object ) );
-	}
-
-	function encode_to_array( $object ) {
-		return json_decode( json_encode( $object ), true );
 	}
 
 	function from_json( string $string ): object {

--- a/tests/unit/APNSAlertTest.php
+++ b/tests/unit/APNSAlertTest.php
@@ -6,20 +6,20 @@ class APNSAlertTest extends APNSTest {
 		$body = 'body';
 
 		$alert = new APNSAlert( $title, $body );
-		$this->assertEquals( $title, $this->encode( $alert )->title );
-		$this->assertEquals( $body, $this->encode( $alert )->body );
+		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
+		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
 	}
 
 	public function testThatAlertTitleSetterWorks() {
 		$title = 'title';
 		$alert = $this->new_alert()->setTitle( $title );
-		$this->assertEquals( $title, $this->encode( $alert )->title );
+		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
 	}
 
 	public function testThatAlertBodySetterWorks() {
 		$body = 'body';
 		$alert = $this->new_alert()->setBody( $body );
-		$this->assertEquals( $body, $this->encode( $alert )->body );
+		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
 	}
 
 	public function testThatLocalizedTitleKeyIsNotPresentByDefault() {
@@ -29,36 +29,36 @@ class APNSAlertTest extends APNSTest {
 	public function testThatLocalizedTitleKeySetterWorks() {
 		$key = 'key';
 		$alert = $this->new_alert()->setLocalizedTitleKey( $key );
-		$this->assertEquals( $key, $this->encode( $alert )->{'title-loc-key'} );
+		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'title-loc-key'} );
 	}
 
 	public function testThatLocalizedTitleArgsSetterWorks() {
 		$args = [ 'foo', 1, 1.25, '1.25', null ];
 		$alert = $this->new_alert()->setLocalizedTitleArgs( $args );
-		$this->assertEquals( $args, $this->encode( $alert )->{'title-loc-args'} );
+		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'title-loc-args'} );
 	}
 
 	public function testThatLocalizedActionKeySetterWorks() {
 		$key = 'key';
 		$alert = $this->new_alert()->setLocalizedActionKey( $key );
-		$this->assertEquals( $key, $this->encode( $alert )->{'action-loc-key'} );
+		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'action-loc-key'} );
 	}
 
 	public function testThatAlertLocalizedMessageKeySetterWorks() {
 		$key = 'key';
 		$alert = $this->new_alert()->setLocalizedMessageKey( $key );
-		$this->assertEquals( $key, $this->encode( $alert )->{'loc-key'} );
+		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'loc-key'} );
 	}
 
 	public function testThatAlertLocalizedMessageArgsSetterWorks() {
 		$args = [ 'foo', 1, 1.25, '1.25', null ];
 		$alert = $this->new_alert()->setLocalizedMessageArgs( $args );
-		$this->assertEquals( $args, $this->encode( $alert )->{'loc-args'} );
+		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'loc-args'} );
 	}
 
 	public function testThatAlertLaunchImageSetterWorks() {
 		$name = 'file-name';
 		$alert = $this->new_alert()->setLaunchImage( $name );
-		$this->assertEquals( $name, $this->encode( $alert )->{'launch-image'} );
+		$this->assertEquals( $name, $this->to_stdclass( $alert )->{'launch-image'} );
 	}
 }

--- a/tests/unit/APNSConfigurationTest.php
+++ b/tests/unit/APNSConfigurationTest.php
@@ -9,7 +9,7 @@ class APNSConfigurationTest extends APNSTest {
 
 	public function testThatProductionEndpointIsCorrect() {
 		$config = APNSConfiguration::production( $this->new_credentials() );
-		$this->assertEquals( $config->get_endpoint(), APNSConfiguration::APNS_ENDPOINT_PRODUCTION );
+		$this->assertEquals( $config->getEndpoint(), APNSConfiguration::APNS_ENDPOINT_PRODUCTION );
 	}
 
 	public function testThatSandboxInitializerUsesSandboxEnvironment() {
@@ -19,7 +19,7 @@ class APNSConfigurationTest extends APNSTest {
 
 	public function testThatSandboxEndpointIsCorrect() {
 		$config = APNSConfiguration::sandbox( $this->new_credentials() );
-		$this->assertEquals( $config->get_endpoint(), APNSConfiguration::APNS_ENDPOINT_SANDBOX );
+		$this->assertEquals( $config->getEndpoint(), APNSConfiguration::APNS_ENDPOINT_SANDBOX );
 	}
 
 	// This should be impossible to hit, but just in case, we'll make sure it works
@@ -27,7 +27,7 @@ class APNSConfigurationTest extends APNSTest {
 		$config = APNSConfiguration::sandbox( $this->new_credentials() );
 		$this->replace_object_key_with_value( $config, 'environment', $this->random_string() );
 		$this->expectException( OutOfBoundsException::class );
-		$config->get_endpoint();
+		$config->getEndpoint();
 	}
 
 	public function testThatUserAgentSetterWorks() {

--- a/tests/unit/APNSPayloadTest.php
+++ b/tests/unit/APNSPayloadTest.php
@@ -5,13 +5,13 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatAlertSetterWorksForAlertObjects() {
 		$alert = $this->new_alert();
 		$push = $this->new_payload()->setAlert( $alert );
-		$this->assertEquals( $this->encode( $alert ), $this->encode( $push )->aps->alert );
+		$this->assertEquals( $this->to_stdclass( $alert ), $this->to_stdclass( $push )->aps->alert );
 	}
 
 	public function testThatAlertSetterWorksForStrings() {
 		$alert = $this->random_string();
 		$push = $this->new_payload()->setAlert( $alert );
-		$this->assertEquals( $alert, $this->encode( $push )->aps->alert );
+		$this->assertEquals( $alert, $this->to_stdclass( $push )->aps->alert );
 	}
 
 	public function testThatAlertSetterThrowsForInvalidValues() {
@@ -20,20 +20,20 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatSoundIsNotPresentByDefault() {
-		$object = $this->encode( $this->new_payload() );
+		$object = $this->to_stdclass( $this->new_payload() );
 		$this->assertKeyIsNotPresentForObject( 'sound', $object->aps );
 	}
 
 	public function testThatSoundSetterWorksForStrings() {
 		$sound = $this->random_string();
 		$push = $this->new_payload()->setSound( $sound );
-		$this->assertEquals( $sound, $this->encode( $push )->aps->sound );
+		$this->assertEquals( $sound, $this->to_stdclass( $push )->aps->sound );
 	}
 
 	public function testThatSoundSetterWorksForSoundObjects() {
 		$sound = $this->new_sound();
 		$push = $this->new_payload()->setSound( $sound );
-		$this->assertEquals( $this->encode( $sound ), $this->encode( $push )->aps->sound );
+		$this->assertEquals( $this->to_stdclass( $sound ), $this->to_stdclass( $push )->aps->sound );
 	}
 
 	public function testThatSoundSetterThrowsForInvalidValues() {
@@ -42,14 +42,14 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatBadgeCountIsNotPresentByDefault() {
-		$object = $this->encode( $this->new_payload() );
+		$object = $this->to_stdclass( $this->new_payload() );
 		$this->assertKeyIsNotPresentForObject( 'badge', $object->aps );
 	}
 
 	public function testThatBadgeCountSetterWorks() {
 		$badge_count = random_int( 1, 99 );
 		$push = $this->new_payload()->setBadgeCount( $badge_count );
-		$this->assertEquals( $badge_count, $this->encode( $push )->aps->badge );
+		$this->assertEquals( $badge_count, $this->to_stdclass( $push )->aps->badge );
 	}
 
 	public function testThatContentAvailableIsNotPresentByDefault() {
@@ -58,10 +58,10 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatSetContentAvailableWorks() {
 		$push = $this->new_payload()->setContentAvailable( true );
-		$this->assertEquals( 1, $this->encode( $push )->aps->{'content-available'} );
+		$this->assertEquals( 1, $this->to_stdclass( $push )->aps->{'content-available'} );
 
 		$push = $push->setContentAvailable( false );
-		$this->assertEquals( 0, $this->encode( $push )->aps->{'content-available'} );
+		$this->assertEquals( 0, $this->to_stdclass( $push )->aps->{'content-available'} );
 	}
 
 	public function testThatMutableContentIsNotPresentByDefault() {
@@ -70,10 +70,10 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatMutableContentSetterWorks() {
 		$push = $this->new_payload()->setMutableContent( true );
-		$this->assertEquals( 1, $this->encode( $push )->aps->{'mutable-content'} );
+		$this->assertEquals( 1, $this->to_stdclass( $push )->aps->{'mutable-content'} );
 
 		$push = $push->setMutableContent( false );
-		$this->assertEquals( 0, $this->encode( $push )->aps->{'mutable-content'} );
+		$this->assertEquals( 0, $this->to_stdclass( $push )->aps->{'mutable-content'} );
 	}
 
 	public function testThatTargetContentIdIsNotPresentByDefault() {
@@ -83,7 +83,7 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatTargetContentIdSetterWorks() {
 		$id = $this->random_string();
 		$push = $this->new_payload()->setTargetContentId( $id );
-		$this->assertEquals( $id, $this->encode( $push )->aps->{'target-content-id'} );
+		$this->assertEquals( $id, $this->to_stdclass( $push )->aps->{'target-content-id'} );
 	}
 
 	public function testThatCategoryIsNotPresentByDefault() {
@@ -93,7 +93,7 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatCategorySetterWorks() {
 		$category = $this->random_string();
 		$push = $this->new_payload()->setCategory( $category );
-		$this->assertEquals( $category, $this->encode( $push )->aps->category );
+		$this->assertEquals( $category, $this->to_stdclass( $push )->aps->category );
 	}
 
 	public function testThatThreadIdIsNotPresentByDefault() {
@@ -103,12 +103,12 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatThreadIdSetterWorks() {
 		$thread = $this->random_string();
 		$push = $this->new_payload()->setThreadId( $thread );
-		$this->assertEquals( $thread, $this->encode( $push )->aps->{'thread-id'} );
+		$this->assertEquals( $thread, $this->to_stdclass( $push )->aps->{'thread-id'} );
 	}
 
 	// The only key that should be present by default is `aps`
 	public function testThatNoCustomDataIsPresentByDefault() {
-		$push = $this->encode( $this->new_payload() );
+		$push = $this->to_stdclass( $this->new_payload() );
 		$this->assertEquals( 1, count( get_object_vars( $push ) ) );
 		$this->assertEquals( 'aps', array_keys( get_object_vars( $push ) )[0] );
 	}
@@ -119,8 +119,8 @@ class APNSPayloadTest extends APNSTest {
 			'baz' => [ 1.0, 1, '1', 0x1 ],
 		];
 		$push = $this->new_payload()->setCustomData( $custom_data );
-		$object = $this->encode_to_array( $push );
-		unset( $object['aps'] );
-		$this->assertEquals( $custom_data, $object );
+		$object = $this->to_stdclass( $push );
+		unset( $object->aps );
+		$this->assertEquals( $custom_data, (array) $object );
 	}
 }

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -10,6 +10,14 @@ class APNSRequestTest extends APNSTest {
 		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
 	}
 
+	public function testRequestInstantiationFromPayload() {
+		$message = $this->random_string();
+		$token = $this->random_string();
+
+		$request = APNSRequest::fromPayload( new APNSPayload( $message ), $token, $this->new_metadata() );
+		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
+	}
+
 	public function testThatGetTokenRetrievesToken() {
 		$message = $this->random_string();
 		$token = $this->random_string();
@@ -20,7 +28,7 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetBodyRetrievesJSONEncodedPush() {
 		$push = $this->new_payload();
-		$this->assertEquals( json_encode( $push ), $this->new_request( $push )->getBody() );
+		$this->assertEquals( $push->toJSON(), $this->new_request( $push )->getBody() );
 	}
 
 	public function testThatGetUuidRetrievesUuid() {
@@ -65,7 +73,7 @@ class APNSRequestTest extends APNSTest {
 		$headers = $this->new_request( $push )->getHeadersForConfiguration( $configuration );
 
 		$this->assertArrayHasKey( 'content-length', $headers );
-		$this->assertEquals( strlen( json_encode( $push ) ), $headers['content-length'] );
+		$this->assertEquals( strlen( $push->toJSON() ), $headers['content-length'] );
 	}
 
 	public function testThatGetHeadersContainsAPNSExpiration() {
@@ -167,7 +175,7 @@ class APNSRequestTest extends APNSTest {
 		$payload = $this->new_payload();
 		$request = $this->decode( $this->new_request( $payload )->toJSON() );
 
-		$this->assertEquals( json_encode( $payload ), $request->payload );
+		$this->assertEquals( $payload->toJSON(), $request->payload );
 	}
 
 	public function testThatRequestSerializationIncludesMetadata() {
@@ -186,7 +194,7 @@ class APNSRequestTest extends APNSTest {
 	public function testThatRequestDeserializationIncludesPayload() {
 		$payload = $this->new_payload();
 		$request = APNSRequest::fromJSON( $this->new_request( $payload )->toJSON() );
-		$this->assertEquals( json_encode( $payload ), $request->getBody() );
+		$this->assertEquals( $payload->toJSON(), $request->getBody() );
 	}
 
 	public function testThatRequestDeserializationIncludesToken() {

--- a/tests/unit/APNSSoundTest.php
+++ b/tests/unit/APNSSoundTest.php
@@ -11,7 +11,7 @@ class APNSSoundTest extends APNSTest {
 	public function testThatNameSetterWorks() {
 		$name = $this->random_string();
 		$sound = $this->new_sound()->setName( $name );
-		$this->assertEquals( $name, $this->encode( $sound )->name );
+		$this->assertEquals( $name, $this->to_stdclass( $sound )->name );
 	}
 
 	public function testThatDefaultVolumeIsMax() {


### PR DESCRIPTION
- Makes the `APNSConfiguration.getEndpoint` method have consistent casing
- Adds a `toJSON` method on `APNSPayload` that provides consistency with other encodable objects and consistency when encoding.