### PR TITLE
Add certificate bundle path support

### DIFF
--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -30,7 +30,10 @@ class APNSClient {
 	public function sendRequests( array $requests ): array {
 		foreach ( $requests as $request ) {
 			assert( get_class( $request ) === APNSRequest::class );
-			$this->enqueueRequest( $request );
+
+			$url = $request->getUrlForConfiguration( $this->configuration );
+			$headers = $request->getHeadersForConfiguration( $this->configuration );
+			$this->network_service->enqueueRequest( $url, $this->convertRequestHeaders( $headers ), $request->getBody() );
 		}
 
 		return $this->network_service->sendQueuedRequests();
@@ -50,12 +53,6 @@ class APNSClient {
 		return $this;
 	}
 
-	private function enqueueRequest( APNSRequest $request ): void {
-		$headers = $request->getHeadersForConfiguration( $this->configuration );
-		$headers = $this->convertRequestHeaders( $headers );
-		$url = $request->getUrlForConfiguration( $this->configuration );
-
-		$this->network_service->enqueueRequest( $url, $headers, $request->getBody() );
 	}
 
 	/**

--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -18,8 +18,9 @@ class APNSClient {
 		return new APNSClient( $configuration, $network_service );
 	}
 
-	public function setPortNumber( int $port ): void {
+	public function setPortNumber( int $port ): self {
 		$this->network_service->setPort( $port );
+		return $this;
 	}
 
 	/**
@@ -39,8 +40,9 @@ class APNSClient {
 		return $this->network_service->sendQueuedRequests();
 	}
 
-	public function close(): void {
+	public function close(): self {
 		$this->network_service->closeConnection();
+		return $this;
 	}
 
 	public function setDebug( bool $debug ): self {

--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -9,14 +9,9 @@ class APNSClient {
 	/** @var APNSConfiguration */
 	private $configuration;
 
-	/** @var string */
-	private $provider_token;
-
 	public function __construct( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ) {
 		$this->configuration = $configuration;
 		$this->network_service = $network_service ?? new APNSNetworkService();
-
-		$this->refreshToken();
 	}
 
 	public static function withConfiguration( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ): self {
@@ -25,11 +20,6 @@ class APNSClient {
 
 	public function setPortNumber( int $port ): void {
 		$this->network_service->setPort( $port );
-	}
-
-	// Can't be overridden, otherwise the subclass might not correctly refresh the token
-	public final function refreshToken(): void {
-		$this->provider_token = $this->configuration->getProviderToken();
 	}
 
 	/**

--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -55,6 +55,9 @@ class APNSClient {
 		return $this;
 	}
 
+	public function setCertificateBundlePath( string $path ): self {
+		$this->network_service->setCertificateBundlePath( $path );
+		return $this;
 	}
 
 	/**

--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -15,6 +15,9 @@ class APNSNetworkService {
 	/** @var bool **/
 	private $ssl_verification_enabled = true;
 
+	/** @var string **/
+	private $certificate_bundle_path;
+
 	public function __construct() {
 		$ch = curl_multi_init();
 		curl_multi_setopt( $ch, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX );
@@ -43,6 +46,9 @@ class APNSNetworkService {
 		// curl_multi_setopt( $ch, CURLOPT_PIPEWAIT, 1 );
 
 		$this->curl_handle = $ch;
+
+		// Use the default certificate bundle path until one is provided
+		$this->certificate_bundle_path = ! empty( ini_get( 'curl.cainfo' ) ) ? ini_get( 'curl.cainfo' ) : ini_get( 'openssl.cafile' );
 	}
 
 	public function setPort( int $port ): self {
@@ -60,6 +66,11 @@ class APNSNetworkService {
 		return $this;
 	}
 
+	public function setCertificateBundlePath( string $path ): self {
+		$this->certificate_bundle_path = $path;
+		return $this;
+	}
+
 	public function enqueueRequest( string $url, array $headers, string $body ): void {
 		$ch = curl_init( $url );
 		curl_setopt( $ch, CURLOPT_HEADER, true );
@@ -70,6 +81,7 @@ class APNSNetworkService {
 		curl_setopt( $ch, CURLOPT_POSTFIELDS, $body );
 		curl_setopt( $ch, CURLOPT_VERBOSE, $this->debug );
 		curl_setopt( $ch, CURLOPT_PORT, $this->port );
+		curl_setopt( $ch, CURLOPT_CAINFO, $this->certificate_bundle_path );
 		curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, $this->ssl_verification_enabled );
 
 		curl_multi_add_handle( $this->curl_handle, $ch );

--- a/tests/smoke/APNSClientSmokeTest.php
+++ b/tests/smoke/APNSClientSmokeTest.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * A smoke test to find basic compilation errors in `APNSClient.php`
+ *
+ * @covers APNSClient
+ */
+class APNSClientSmokeTest extends APNSTest {
+
+	public function testThatSetPortNumberWorks() {
+		$client = ( new APNSClient( $this->new_configuration() ) )->setPortNumber( random_int( 1, 65535 ) );
+		$this->assertNotNull( $client );
+	}
+
+	public function testThatSetDebugWorks() {
+		$client = ( new APNSClient( $this->new_configuration() ) )->setDebug( true );
+		$this->assertNotNull( $client );
+	}
+
+	public function testThatSetDisableSSLWorks() {
+		$client = ( new APNSClient( $this->new_configuration() ) )->setDisableSSLVerification( true );
+		$this->assertNotNull( $client );
+	}
+
+	public function testThatSetCertificateBundlePathWorks() {
+		$client = ( new APNSClient( $this->new_configuration() ) )->setCertificateBundlePath( $this->random_string() );
+		$this->assertNotNull( $client );
+	}
+
+	public function testThatCloseWorks() {
+		$client = ( new APNSClient( $this->new_configuration() ) )->close();
+		$this->assertNotNull( $client );
+	}
+}

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,5 @@
+# Smoke Tests
+
+Smoke tests aren't designed to validate functionality, they're designed to validate that we didn't fat-finger a function name or pass the wrong type of argument around.
+
+They're really only useful for ensuring the areas of code that we haven't tested in-depth (or have no reason to do deep tests on) don't break unexpectedly.


### PR DESCRIPTION
For some builds of Debian, [the Apple Geotrust certificate isn't trusted](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962596).

There are many contexts where something like this can happen, so we'll provide the ability to define external certificate storage.

--- 

Grouped with this PR is some `APNSClient` refactoring to simplify the implementation a bit, and a new kind of test – smoke tests! They're really basic tests to ensure we didn't mis-spell a method name or something (though Psalm does kind of the same thing...). Interested to hear your feedback on it 😄 
