### PR TITLE
Add accessors to Alerts and Payloads

### DIFF
--- a/src/model/APNSAlert.php
+++ b/src/model/APNSAlert.php
@@ -37,9 +37,17 @@ class APNSAlert implements JsonSerializable {
 		return new APNSAlert( $string );
 	}
 
+	function getTitle(): string {
+		return $this->title;
+	}
+
 	function setTitle( string $title ): self {
 		$this->title = $title;
 		return $this;
+	}
+
+	function getBody(): ?string {
+		return $this->body;
 	}
 
 	function setBody( string $body ): self {
@@ -47,9 +55,17 @@ class APNSAlert implements JsonSerializable {
 		return $this;
 	}
 
+	function getLocalizedTitleKey(): ?string {
+		return $this->localized_title_key;
+	}
+
 	function setLocalizedTitleKey( string $key ): self {
 		$this->localized_title_key = $key;
 		return $this;
+	}
+
+	function getLocalizedTitleArgs(): ?array {
+		return $this->localized_title_args;
 	}
 
 	function setLocalizedTitleArgs( array $args ): self {
@@ -57,9 +73,17 @@ class APNSAlert implements JsonSerializable {
 		return $this;
 	}
 
+	function getLocalizedActionKey(): ?string {
+		return $this->localized_action_key;
+	}
+
 	function setLocalizedActionKey( string $key ): self {
 		$this->localized_action_key = $key;
 		return $this;
+	}
+
+	function getLocalizedMessageKey(): ?string {
+		return $this->localized_message_key;
 	}
 
 	function setLocalizedMessageKey( string $key ): self {
@@ -67,9 +91,17 @@ class APNSAlert implements JsonSerializable {
 		return $this;
 	}
 
+	function getLocalizedMessageArgs(): ?array {
+		return $this->localized_message_args;
+	}
+
 	function setLocalizedMessageArgs( array $args ): self {
 		$this->localized_message_args = $args;
 		return $this;
+	}
+
+	function getLaunchImage(): ?string {
+		return $this->launch_image;
 	}
 
 	function setLaunchImage( string $name ): self {

--- a/src/model/APNSAlert.php
+++ b/src/model/APNSAlert.php
@@ -4,55 +4,103 @@ declare( strict_types = 1 );
 // Keys defined at https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943365
 class APNSAlert implements JsonSerializable {
 
-	/** @var array */
-	protected $internal = [];
+	/** @var string */
+	protected $title;
 
-	function __construct( string $title, string $body ) {
-		$this->internal['title'] = $title;
-		$this->internal['body'] = $body;
+	/** @var ?string */
+	protected $body;
+
+	/** @var ?string */
+	protected $localized_title_key;
+
+	/** @var ?array */
+	protected $localized_title_args = null;
+
+	/** @var ?string */
+	protected $localized_action_key;
+
+	/** @var ?string */
+	protected $localized_message_key;
+
+	/** @var ?array */
+	protected $localized_message_args = null;
+
+	/** @var ?string */
+	protected $launch_image;
+
+	function __construct( string $title, ?string $body = null ) {
+		$this->title = $title;
+		$this->body = $body;
+	}
+
+	static function fromString( string $string ): APNSAlert {
+		return new APNSAlert( $string );
 	}
 
 	function setTitle( string $title ): self {
-		$this->internal['title'] = $title;
+		$this->title = $title;
 		return $this;
 	}
 
 	function setBody( string $body ): self {
-		$this->internal['body'] = $body;
+		$this->body = $body;
 		return $this;
 	}
 
 	function setLocalizedTitleKey( string $key ): self {
-		$this->internal['title-loc-key'] = $key;
+		$this->localized_title_key = $key;
 		return $this;
 	}
 
 	function setLocalizedTitleArgs( array $args ): self {
-		$this->internal['title-loc-args'] = $args;
+		$this->localized_title_args = $args;
 		return $this;
 	}
 
 	function setLocalizedActionKey( string $key ): self {
-		$this->internal['action-loc-key'] = $key;
+		$this->localized_action_key = $key;
 		return $this;
 	}
 
 	function setLocalizedMessageKey( string $key ): self {
-		$this->internal['loc-key'] = $key;
+		$this->localized_message_key = $key;
 		return $this;
 	}
 
 	function setLocalizedMessageArgs( array $args ): self {
-		$this->internal['loc-args'] = $args;
+		$this->localized_message_args = $args;
 		return $this;
 	}
 
 	function setLaunchImage( string $name ): self {
-		$this->internal['launch-image'] = $name;
+		$this->launch_image = $name;
 		return $this;
 	}
 
 	function jsonSerialize() {
-		return $this->internal;
+
+		$data = [
+			'title' => $this->title,
+			'body' => $this->body,
+			'title-loc-key' => $this->localized_title_key,
+			'title-loc-args' => $this->localized_title_args,
+			'action-loc-key' => $this->localized_action_key,
+			'loc-key' => $this->localized_message_key,
+			'loc-args' => $this->localized_message_args,
+			'launch-image' => $this->launch_image,
+		];
+
+		$output = array_filter(
+			$data, function( $value ) {
+				return ! is_null( $value );
+			}
+		);
+
+		// If only the title is present, return it instead of an object
+		if ( count( $output ) === 1 && array_keys( $output )[0] === 'title' ) {
+			return $this->title;
+		}
+
+		return $output;
 	}
 }

--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -46,6 +46,10 @@ class APNSPayload {
 		return new APNSPayload( APNSAlert::fromString( $string ) );
 	}
 
+	function getAlert(): APNSAlert {
+		return $this->alert;
+	}
+
 	/**
 	 * Set the alert field to the provided APNSAlert object or string.
 	 *
@@ -66,11 +70,22 @@ class APNSPayload {
 		return $this;
 	}
 
+	function getBadgeCount(): ?int {
+		return $this->badge;
 	}
 
 	function setBadgeCount( int $count ): self {
 		$this->badge = $count;
 		return $this;
+	}
+
+	/**
+	 * Returns the currently set `APNSSound` object for this payload, or `null` if none exists.
+	 *
+	 * @return APNSSound|null
+	 */
+	function getSound(): ?APNSSound {
+		return $this->sound;
 	}
 
 	/**
@@ -93,9 +108,17 @@ class APNSPayload {
 		throw new InvalidArgumentException( 'Invalid Sound – you must pass either a string or `APNSSound` object.' );
 	}
 
+	function getIsContentAvailable(): bool {
+		return $this->content_available;
+	}
+
 	function setContentAvailable( bool $content_available ): self {
 		$this->content_available = $content_available;
 		return $this;
+	}
+
+	function getIsMutableContent(): bool {
+		return $this->mutable_content;
 	}
 
 	function setMutableContent( bool $mutable_content ): self {
@@ -103,9 +126,17 @@ class APNSPayload {
 		return $this;
 	}
 
+	function getTargetContentId(): ?string {
+		return $this->target_content_id;
+	}
+
 	function setTargetContentId( string $id ): self {
 		$this->target_content_id = $id;
 		return $this;
+	}
+
+	function getCategory(): ?string {
+		return $this->category;
 	}
 
 	function setCategory( string $category ): self {
@@ -113,9 +144,17 @@ class APNSPayload {
 		return $this;
 	}
 
+	function getThreadId(): ?string {
+		return $this->thread_id;
+	}
+
 	function setThreadId( string $id ): self {
 		$this->thread_id = $id;
 		return $this;
+	}
+
+	function getCustomData(): array {
+		return $this->custom;
 	}
 
 	function setCustomData( array $data ): self {

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -13,7 +13,7 @@ class APNSRequest {
 	private $token;
 
 	static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
-		$payload = new APNSPayload( $payload );
+		$payload = APNSPayload::fromString( $payload );
 		return new APNSRequest( $payload->toJSON(), $token, $metadata );
 	}
 

--- a/src/model/APNSSound.php
+++ b/src/model/APNSSound.php
@@ -19,6 +19,10 @@ class APNSSound implements JsonSerializable {
 		$this->setIsCritical( $is_critical );
 	}
 
+	static function fromString( string $name ): APNSSound {
+		return new APNSSound( $name );
+	}
+
 	function getIsCritical(): bool {
 		return $this->is_critical;
 	}
@@ -51,6 +55,12 @@ class APNSSound implements JsonSerializable {
 	}
 
 	function jsonSerialize() {
+
+		// If the volume and `critical` flags haven't been modified, we can just send the filename to save space
+		if ( 1.0 === $this->volume && false === $this->is_critical ) {
+			return $this->name;
+		}
+
 		return [
 			'critical' => $this->is_critical ? 1 : 0,
 			'name' => $this->name,

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -129,6 +129,10 @@ abstract class APNSTest extends TestCase {
 		return json_decode( json_encode( $object ) );
 	}
 
+	function to_string( $object ): string {
+		return json_decode( json_encode( $object ) );
+	}
+
 	function new_apns_http_failure_response( int $status_code, string $reason = 'not read here' ): string {
 		return <<<TEXT
 HTTP/2 $status_code

--- a/tests/unit/APNSAlertTest.php
+++ b/tests/unit/APNSAlertTest.php
@@ -14,6 +14,7 @@ class APNSAlertTest extends APNSTest {
 		$string = $this->random_string();
 
 		$alert = new APNSAlert( $string );
+		$this->assertEquals( $string, $alert->getTitle() );
 		$this->assertEquals( '"' . $string . '"', json_encode( $alert ) );
 	}
 
@@ -28,6 +29,7 @@ class APNSAlertTest extends APNSTest {
 		$body = $this->random_string();
 		$alert = $this->new_alert()->setBody( $body );
 		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
+		$this->assertEquals( $body, $alert->getBody() );
 	}
 
 	public function testThatLocalizedTitleKeyIsNotPresentByDefault() {
@@ -38,35 +40,41 @@ class APNSAlertTest extends APNSTest {
 		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedTitleKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'title-loc-key'} );
+		$this->assertEquals( $key, $alert->getLocalizedTitleKey() );
 	}
 
 	public function testThatLocalizedTitleArgsSetterWorks() {
 		$args = [ 'foo', 1, 1.25, '1.25', null ];
 		$alert = $this->new_alert()->setLocalizedTitleArgs( $args );
 		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'title-loc-args'} );
+		$this->assertEquals( $args, $alert->getLocalizedTitleArgs() );
 	}
 
 	public function testThatLocalizedActionKeySetterWorks() {
 		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedActionKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'action-loc-key'} );
+		$this->assertEquals( $key, $alert->getLocalizedActionKey() );
 	}
 
 	public function testThatAlertLocalizedMessageKeySetterWorks() {
 		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedMessageKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'loc-key'} );
+		$this->assertEquals( $key, $alert->getLocalizedMessageKey() );
 	}
 
 	public function testThatAlertLocalizedMessageArgsSetterWorks() {
 		$args = [ 'foo', 1, 1.25, '1.25', null ];
 		$alert = $this->new_alert()->setLocalizedMessageArgs( $args );
 		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'loc-args'} );
+		$this->assertEquals( $args, $alert->getLocalizedMessageArgs() );
 	}
 
 	public function testThatAlertLaunchImageSetterWorks() {
 		$name = $this->random_string();
 		$alert = $this->new_alert()->setLaunchImage( $name );
 		$this->assertEquals( $name, $this->to_stdclass( $alert )->{'launch-image'} );
+		$this->assertEquals( $name, $alert->getLaunchImage() );
 	}
 }

--- a/tests/unit/APNSAlertTest.php
+++ b/tests/unit/APNSAlertTest.php
@@ -2,8 +2,8 @@
 declare( strict_types = 1 );
 class APNSAlertTest extends APNSTest {
 	public function testThatAlertConstructorStoresTitleAndBody() {
-		$title = 'title';
-		$body = 'body';
+		$title = $this->random_string();
+		$body = $this->random_string();
 
 		$alert = new APNSAlert( $title, $body );
 		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
@@ -25,7 +25,7 @@ class APNSAlertTest extends APNSTest {
 	}
 
 	public function testThatAlertBodySetterWorks() {
-		$body = 'body';
+		$body = $this->random_string();
 		$alert = $this->new_alert()->setBody( $body );
 		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
 	}
@@ -35,7 +35,7 @@ class APNSAlertTest extends APNSTest {
 	}
 
 	public function testThatLocalizedTitleKeySetterWorks() {
-		$key = 'key';
+		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedTitleKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'title-loc-key'} );
 	}
@@ -47,13 +47,13 @@ class APNSAlertTest extends APNSTest {
 	}
 
 	public function testThatLocalizedActionKeySetterWorks() {
-		$key = 'key';
+		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedActionKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'action-loc-key'} );
 	}
 
 	public function testThatAlertLocalizedMessageKeySetterWorks() {
-		$key = 'key';
+		$key = $this->random_string();
 		$alert = $this->new_alert()->setLocalizedMessageKey( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'loc-key'} );
 	}
@@ -65,7 +65,7 @@ class APNSAlertTest extends APNSTest {
 	}
 
 	public function testThatAlertLaunchImageSetterWorks() {
-		$name = 'file-name';
+		$name = $this->random_string();
 		$alert = $this->new_alert()->setLaunchImage( $name );
 		$this->assertEquals( $name, $this->to_stdclass( $alert )->{'launch-image'} );
 	}

--- a/tests/unit/APNSAlertTest.php
+++ b/tests/unit/APNSAlertTest.php
@@ -10,10 +10,18 @@ class APNSAlertTest extends APNSTest {
 		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
 	}
 
-	public function testThatAlertTitleSetterWorks() {
-		$title = 'title';
+	public function testThatAlertWithoutBodySerializesToString() {
+		$string = $this->random_string();
+
+		$alert = new APNSAlert( $string );
+		$this->assertEquals( '"' . $string . '"', json_encode( $alert ) );
+	}
+
+	public function testThatAlertTitleSetterWorksForStrings() {
+		$title = $this->random_string();
 		$alert = $this->new_alert()->setTitle( $title );
 		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
+		$this->assertEquals( $title, $alert->getTitle() );
 	}
 
 	public function testThatAlertBodySetterWorks() {

--- a/tests/unit/APNSPayloadTest.php
+++ b/tests/unit/APNSPayloadTest.php
@@ -4,14 +4,14 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatAlertSetterWorksForAlertObjects() {
 		$alert = $this->new_alert();
-		$push = $this->new_payload()->setAlert( $alert );
-		$this->assertEquals( $this->to_stdclass( $alert ), $this->to_stdclass( $push )->aps->alert );
+		$payload = $this->new_payload()->setAlert( $alert );
+		$this->assertEquals( $this->to_stdclass( $alert ), $this->to_stdclass( $payload )->aps->alert );
 	}
 
 	public function testThatAlertSetterWorksForStrings() {
 		$alert = $this->random_string();
-		$push = $this->new_payload()->setAlert( $alert );
-		$this->assertEquals( $alert, $this->to_stdclass( $push )->aps->alert );
+		$payload = $this->new_payload()->setAlert( $alert );
+		$this->assertEquals( $alert, $this->to_stdclass( $payload )->aps->alert );
 	}
 
 	public function testThatAlertSetterThrowsForInvalidValues() {
@@ -26,14 +26,14 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatSoundSetterWorksForStrings() {
 		$sound = $this->random_string();
-		$push = $this->new_payload()->setSound( $sound );
-		$this->assertEquals( $sound, $this->to_stdclass( $push )->aps->sound );
+		$payload = $this->new_payload()->setSound( $sound );
+		$this->assertEquals( $sound, $this->to_stdclass( $payload )->aps->sound );
 	}
 
 	public function testThatSoundSetterWorksForSoundObjects() {
 		$sound = $this->new_sound();
-		$push = $this->new_payload()->setSound( $sound );
-		$this->assertEquals( $this->to_stdclass( $sound ), $this->to_stdclass( $push )->aps->sound );
+		$payload = $this->new_payload()->setSound( $sound );
+		$this->assertEquals( $sound->getName(), $this->to_stdclass( $payload )->aps->sound );
 	}
 
 	public function testThatSoundSetterThrowsForInvalidValues() {
@@ -48,8 +48,8 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatBadgeCountSetterWorks() {
 		$badge_count = random_int( 1, 99 );
-		$push = $this->new_payload()->setBadgeCount( $badge_count );
-		$this->assertEquals( $badge_count, $this->to_stdclass( $push )->aps->badge );
+		$payload = $this->new_payload()->setBadgeCount( $badge_count );
+		$this->assertEquals( $badge_count, $this->to_stdclass( $payload )->aps->badge );
 	}
 
 	public function testThatContentAvailableIsNotPresentByDefault() {
@@ -57,11 +57,11 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatSetContentAvailableWorks() {
-		$push = $this->new_payload()->setContentAvailable( true );
-		$this->assertEquals( 1, $this->to_stdclass( $push )->aps->{'content-available'} );
+		$payload = $this->new_payload()->setContentAvailable( true );
+		$this->assertEquals( 1, $this->to_stdclass( $payload )->aps->{'content-available'} );
 
-		$push = $push->setContentAvailable( false );
-		$this->assertEquals( 0, $this->to_stdclass( $push )->aps->{'content-available'} );
+		$payload = $payload->setContentAvailable( false );
+		$this->assertEquals( 0, $this->to_stdclass( $payload )->aps->{'content-available'} );
 	}
 
 	public function testThatMutableContentIsNotPresentByDefault() {
@@ -69,11 +69,11 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatMutableContentSetterWorks() {
-		$push = $this->new_payload()->setMutableContent( true );
-		$this->assertEquals( 1, $this->to_stdclass( $push )->aps->{'mutable-content'} );
+		$payload = $this->new_payload()->setMutableContent( true );
+		$this->assertEquals( 1, $this->to_stdclass( $payload )->aps->{'mutable-content'} );
 
-		$push = $push->setMutableContent( false );
-		$this->assertEquals( 0, $this->to_stdclass( $push )->aps->{'mutable-content'} );
+		$payload = $payload->setMutableContent( false );
+		$this->assertEquals( 0, $this->to_stdclass( $payload )->aps->{'mutable-content'} );
 	}
 
 	public function testThatTargetContentIdIsNotPresentByDefault() {
@@ -82,8 +82,8 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatTargetContentIdSetterWorks() {
 		$id = $this->random_string();
-		$push = $this->new_payload()->setTargetContentId( $id );
-		$this->assertEquals( $id, $this->to_stdclass( $push )->aps->{'target-content-id'} );
+		$payload = $this->new_payload()->setTargetContentId( $id );
+		$this->assertEquals( $id, $this->to_stdclass( $payload )->aps->{'target-content-id'} );
 	}
 
 	public function testThatCategoryIsNotPresentByDefault() {
@@ -92,8 +92,8 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatCategorySetterWorks() {
 		$category = $this->random_string();
-		$push = $this->new_payload()->setCategory( $category );
-		$this->assertEquals( $category, $this->to_stdclass( $push )->aps->category );
+		$payload = $this->new_payload()->setCategory( $category );
+		$this->assertEquals( $category, $this->to_stdclass( $payload )->aps->category );
 	}
 
 	public function testThatThreadIdIsNotPresentByDefault() {
@@ -102,15 +102,14 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatThreadIdSetterWorks() {
 		$thread = $this->random_string();
-		$push = $this->new_payload()->setThreadId( $thread );
-		$this->assertEquals( $thread, $this->to_stdclass( $push )->aps->{'thread-id'} );
+		$payload = $this->new_payload()->setThreadId( $thread );
+		$this->assertEquals( $thread, $this->to_stdclass( $payload )->aps->{'thread-id'} );
 	}
 
 	// The only key that should be present by default is `aps`
 	public function testThatNoCustomDataIsPresentByDefault() {
-		$push = $this->to_stdclass( $this->new_payload() );
-		$this->assertEquals( 1, count( get_object_vars( $push ) ) );
-		$this->assertEquals( 'aps', array_keys( get_object_vars( $push ) )[0] );
+		$payload = $this->to_stdclass( $this->new_payload() );
+		$this->assertEquals( 1, count( get_object_vars( $payload ) ) );
 	}
 
 	public function testThatCustomDataSetterWorks() {
@@ -118,8 +117,8 @@ class APNSPayloadTest extends APNSTest {
 			'foo' => 'bar',
 			'baz' => [ 1.0, 1, '1', 0x1 ],
 		];
-		$push = $this->new_payload()->setCustomData( $custom_data );
-		$object = $this->to_stdclass( $push );
+		$payload = $this->new_payload()->setCustomData( $custom_data );
+		$object = $this->to_stdclass( $payload );
 		unset( $object->aps );
 		$this->assertEquals( $custom_data, (array) $object );
 	}

--- a/tests/unit/APNSPayloadTest.php
+++ b/tests/unit/APNSPayloadTest.php
@@ -12,6 +12,7 @@ class APNSPayloadTest extends APNSTest {
 		$alert = $this->random_string();
 		$payload = $this->new_payload()->setAlert( $alert );
 		$this->assertEquals( $alert, $this->to_stdclass( $payload )->aps->alert );
+		$this->assertEquals( $alert, $payload->getAlert()->getTitle() );
 	}
 
 	public function testThatAlertSetterThrowsForInvalidValues() {
@@ -28,12 +29,14 @@ class APNSPayloadTest extends APNSTest {
 		$sound = $this->random_string();
 		$payload = $this->new_payload()->setSound( $sound );
 		$this->assertEquals( $sound, $this->to_stdclass( $payload )->aps->sound );
+		$this->assertEquals( $sound, $payload->getSound()->getName() );
 	}
 
 	public function testThatSoundSetterWorksForSoundObjects() {
 		$sound = $this->new_sound();
 		$payload = $this->new_payload()->setSound( $sound );
 		$this->assertEquals( $sound->getName(), $this->to_stdclass( $payload )->aps->sound );
+		$this->assertEquals( $sound, $payload->getSound() );
 	}
 
 	public function testThatSoundSetterThrowsForInvalidValues() {
@@ -50,6 +53,7 @@ class APNSPayloadTest extends APNSTest {
 		$badge_count = random_int( 1, 99 );
 		$payload = $this->new_payload()->setBadgeCount( $badge_count );
 		$this->assertEquals( $badge_count, $this->to_stdclass( $payload )->aps->badge );
+		$this->assertEquals( $badge_count, $payload->getBadgeCount() );
 	}
 
 	public function testThatContentAvailableIsNotPresentByDefault() {
@@ -59,9 +63,11 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatSetContentAvailableWorks() {
 		$payload = $this->new_payload()->setContentAvailable( true );
 		$this->assertEquals( 1, $this->to_stdclass( $payload )->aps->{'content-available'} );
+		$this->assertTrue( $payload->getIsContentAvailable() );
 
 		$payload = $payload->setContentAvailable( false );
 		$this->assertEquals( 0, $this->to_stdclass( $payload )->aps->{'content-available'} );
+		$this->assertFalse( $payload->getIsContentAvailable() );
 	}
 
 	public function testThatMutableContentIsNotPresentByDefault() {
@@ -71,9 +77,11 @@ class APNSPayloadTest extends APNSTest {
 	public function testThatMutableContentSetterWorks() {
 		$payload = $this->new_payload()->setMutableContent( true );
 		$this->assertEquals( 1, $this->to_stdclass( $payload )->aps->{'mutable-content'} );
+		$this->assertTrue( $payload->getIsMutableContent() );
 
 		$payload = $payload->setMutableContent( false );
 		$this->assertEquals( 0, $this->to_stdclass( $payload )->aps->{'mutable-content'} );
+		$this->assertFalse( $payload->getIsMutableContent() );
 	}
 
 	public function testThatTargetContentIdIsNotPresentByDefault() {
@@ -84,6 +92,7 @@ class APNSPayloadTest extends APNSTest {
 		$id = $this->random_string();
 		$payload = $this->new_payload()->setTargetContentId( $id );
 		$this->assertEquals( $id, $this->to_stdclass( $payload )->aps->{'target-content-id'} );
+		$this->assertEquals( $id, $payload->getTargetContentId() );
 	}
 
 	public function testThatCategoryIsNotPresentByDefault() {
@@ -94,6 +103,7 @@ class APNSPayloadTest extends APNSTest {
 		$category = $this->random_string();
 		$payload = $this->new_payload()->setCategory( $category );
 		$this->assertEquals( $category, $this->to_stdclass( $payload )->aps->category );
+		$this->assertEquals( $category, $payload->getCategory() );
 	}
 
 	public function testThatThreadIdIsNotPresentByDefault() {
@@ -104,12 +114,14 @@ class APNSPayloadTest extends APNSTest {
 		$thread = $this->random_string();
 		$payload = $this->new_payload()->setThreadId( $thread );
 		$this->assertEquals( $thread, $this->to_stdclass( $payload )->aps->{'thread-id'} );
+		$this->assertEquals( $thread, $payload->getThreadId() );
 	}
 
 	// The only key that should be present by default is `aps`
 	public function testThatNoCustomDataIsPresentByDefault() {
 		$payload = $this->to_stdclass( $this->new_payload() );
 		$this->assertEquals( 1, count( get_object_vars( $payload ) ) );
+		$this->assertEquals( 'aps', array_keys( get_object_vars( $payload ) )[0] );
 	}
 
 	public function testThatCustomDataSetterWorks() {
@@ -121,5 +133,6 @@ class APNSPayloadTest extends APNSTest {
 		$object = $this->to_stdclass( $payload );
 		unset( $object->aps );
 		$this->assertEquals( $custom_data, (array) $object );
+		$this->assertEquals( $custom_data, $payload->getCustomData() );
 	}
 }

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -14,7 +14,7 @@ class APNSRequestTest extends APNSTest {
 		$message = $this->random_string();
 		$token = $this->random_string();
 
-		$request = APNSRequest::fromPayload( new APNSPayload( $message ), $token, $this->new_metadata() );
+		$request = APNSRequest::fromPayload( APNSPayload::fromString( $message ), $token, $this->new_metadata() );
 		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
 	}
 

--- a/tests/unit/APNSSoundTest.php
+++ b/tests/unit/APNSSoundTest.php
@@ -11,7 +11,7 @@ class APNSSoundTest extends APNSTest {
 	public function testThatNameSetterWorks() {
 		$name = $this->random_string();
 		$sound = $this->new_sound()->setName( $name );
-		$this->assertEquals( $name, $this->to_stdclass( $sound )->name );
+		$this->assertEquals( $name, $this->to_string( $sound ) );
 	}
 
 	public function testThatDefaultVolumeIsMax() {
@@ -46,5 +46,22 @@ class APNSSoundTest extends APNSTest {
 
 		$sound = $this->new_sound()->setIsCritical( false );
 		$this->assertFalse( $sound->getIsCritical() );
+	}
+
+	public function testThatSerializationForDefaultsReturnsString() {
+		$name = $this->random_string();
+		$sound = APNSSound::fromString( $name );
+		$this->assertEquals( '"' . $name . '"', json_encode( $sound ) );
+	}
+
+	public function testThatSerializationForCustomVolumeReturnsObject() {
+		$volume = rand( 0, 10 ) / 10;
+		$sound = $this->new_sound()->setVolume( $volume );
+		$this->assertEquals( $volume, $this->to_stdclass( $sound )->volume );
+	}
+
+	public function testThatSerializationForCustomCriticalityReturnsObject() {
+		$sound = $this->new_sound()->setIsCritical( true );
+		$this->assertEquals( 1, $this->to_stdclass( $sound )->critical );
 	}
 }

--- a/tests/unit/APNSSoundTest.php
+++ b/tests/unit/APNSSoundTest.php
@@ -12,6 +12,7 @@ class APNSSoundTest extends APNSTest {
 		$name = $this->random_string();
 		$sound = $this->new_sound()->setName( $name );
 		$this->assertEquals( $name, $this->to_string( $sound ) );
+		$this->assertEquals( $name, $sound->getName() );
 	}
 
 	public function testThatDefaultVolumeIsMax() {


### PR DESCRIPTION
This allows introspecting them at runtime to allow implementing `shouldSendNotification` functionality.

The tests should have this pretty well-covered.

It's probably easiest to review this by commit – there were a few changes stacked on top of each other to make this possible.