### PR TITLE
Don’t manually specify a default cert bundle path

### DIFF
--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -12,7 +12,12 @@ class APNSNetworkService {
 	/** @var bool **/
 	private $debug = false;
 
-	/** @var ?string **/
+	/**
+	 * An optional path to the certificate bundle libcurl should use. By default, we'll use the system one, but on some systems it's necessary
+	 * to override this. One example is Debian, where Apple's Geotrust certificate isn't trusted. (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962596)
+	 *
+	 * @var ?string
+	 **/
 	private $certificate_bundle_path = null;
 
 	public function __construct() {

--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -76,7 +76,7 @@ class APNSNetworkService {
 		curl_setopt( $ch, CURLOPT_VERBOSE, $this->debug );
 		curl_setopt( $ch, CURLOPT_PORT, $this->port );
 
-		if( ! is_null( $this->certificate_bundle_path ) ) {
+		if ( ! is_null( $this->certificate_bundle_path ) ) {
 			curl_setopt( $ch, CURLOPT_CAINFO, $this->certificate_bundle_path );
 		}
 
@@ -146,4 +146,3 @@ class APNSNetworkService {
 		curl_multi_close( $this->curl_handle );
 	}
 }
-

--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -12,8 +12,8 @@ class APNSNetworkService {
 	/** @var bool **/
 	private $debug = false;
 
-	/** @var string **/
-	private $certificate_bundle_path;
+	/** @var ?string **/
+	private $certificate_bundle_path = null;
 
 	public function __construct() {
 		$ch = curl_multi_init();
@@ -43,9 +43,6 @@ class APNSNetworkService {
 		// curl_multi_setopt( $ch, CURLOPT_PIPEWAIT, 1 );
 
 		$this->curl_handle = $ch;
-
-		// Use the default certificate bundle path until one is provided
-		$this->certificate_bundle_path = ! empty( ini_get( 'curl.cainfo' ) ) ? ini_get( 'curl.cainfo' ) : ini_get( 'openssl.cafile' );
 	}
 
 	public function setPort( int $port ): self {
@@ -73,7 +70,10 @@ class APNSNetworkService {
 		curl_setopt( $ch, CURLOPT_POSTFIELDS, $body );
 		curl_setopt( $ch, CURLOPT_VERBOSE, $this->debug );
 		curl_setopt( $ch, CURLOPT_PORT, $this->port );
-		curl_setopt( $ch, CURLOPT_CAINFO, $this->certificate_bundle_path );
+
+		if( ! is_null( $this->certificate_bundle_path ) ) {
+			curl_setopt( $ch, CURLOPT_CAINFO, $this->certificate_bundle_path );
+		}
 
 		curl_multi_add_handle( $this->curl_handle, $ch );
 	}


### PR DESCRIPTION
There are a ton of weird cases where this might not be correct – better to just use the system defaults and only specify a manual path if the user provides one.