### PR TITLE
Align Linter Rules with WordPress.com

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -6,6 +6,7 @@
 	<file>index.php</file>
 
 	<rule ref="NeutronRuleset"/>
+	<rule ref="Squiz.Scope.MethodScope.Missing" />
 	<rule ref="NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions">
 		<exclude-pattern>/examples/db-connect\.php</exclude-pattern>
 	</rule>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -5,16 +5,24 @@
 	<file>examples</file>
 	<file>index.php</file>
 
-	<rule ref="NeutronRuleset"/>
+	<rule ref="WordPress"/>
+
+	<!-- Manually Enable These Rules -->
 	<rule ref="Squiz.Scope.MethodScope.Missing" />
-	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed" />
-	<rule ref="ImportDetection">
-		<exclude-pattern>index.php</exclude-pattern>
-		<exclude-pattern>/examples</exclude-pattern>
-		<exclude-pattern>/src</exclude-pattern>
-		<exclude-pattern>/tests</exclude-pattern>
+
+	<!-- Manually Disable These Rules -->
+	<rule ref="Squiz.Commenting">
+		<severity>0</severity>
 	</rule>
-	<rule ref="NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions">
-		<exclude-pattern>/examples/db-connect\.php</exclude-pattern>
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<!-- TODO: Remove this one once we have comments for everything -->
+		<severity>0</severity>
+	</rule>	
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+	  <severity>0</severity>
+	</rule> -->
+	<rule ref="WordPress.Files.FileName">
+		<severity>0</severity>
 	</rule>
+
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -7,6 +7,13 @@
 
 	<rule ref="NeutronRuleset"/>
 	<rule ref="Squiz.Scope.MethodScope.Missing" />
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed" />
+	<rule ref="ImportDetection">
+		<exclude-pattern>index.php</exclude-pattern>
+		<exclude-pattern>/examples</exclude-pattern>
+		<exclude-pattern>/src</exclude-pattern>
+		<exclude-pattern>/tests</exclude-pattern>
+	</rule>
 	<rule ref="NeutronStandard.Globals.DisallowGlobalFunctions.GlobalFunctions">
 		<exclude-pattern>/examples/db-connect\.php</exclude-pattern>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "vimeo/psalm": "^3.12"
     },
     "scripts": {
-        "lint": "./vendor/bin/phpcs --ignore=tests/MockAPNSServer",
+        "lint": "./vendor/bin/phpcs -s --ignore=tests/MockAPNSServer",
         "fix": "./vendor/bin/phpcbf --ignore=tests/MockAPNSServer",
         "test": "./vendor/bin/phpunit --coverage-clover 'coverage/coverage.xml' --coverage-html 'coverage'",
         "psalm": "./vendor/bin/psalm"

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "vimeo/psalm": "^3.12"
     },
     "scripts": {
-        "lint": "./vendor/bin/phpcs -s --ignore=tests/MockAPNSServer",
-        "fix": "./vendor/bin/phpcbf --ignore=tests/MockAPNSServer",
+        "lint": "./vendor/bin/phpcs -s --ignore=tests/MockAPNSServer/node_modules/",
+        "fix": "./vendor/bin/phpcbf --ignore=tests/MockAPNSServer/node_modules/",
         "test": "./vendor/bin/phpunit --coverage-clover 'coverage/coverage.xml' --coverage-html 'coverage'",
         "psalm": "./vendor/bin/psalm"
     }

--- a/examples/add-to-queue.php
+++ b/examples/add-to-queue.php
@@ -14,10 +14,10 @@ while ( true ) {
 
 	for ( $i = 0; $i < 2; $i++ ) {
 		$message = bin2hex( random_bytes( random_int( 2, 2048 ) ) );
-		$alert = new APNSAlert( 'Title', $message );
-		$payload = APNSPayload::fromAlert( $alert );
+		$alert   = new APNSAlert( 'Title', $message );
+		$payload = APNSPayload::from_alert( $alert );
 
-		$request = APNSRequest::fromPayload( $payload, $token, new APNSRequestMetadata( $topic ) );
+		$request = APNSRequest::from_payload( $payload, $token, new APNSRequestMetadata( $topic ) );
 		save_request( $request );
 	}
 }

--- a/examples/db-connect.php
+++ b/examples/db-connect.php
@@ -7,17 +7,17 @@ use Dotenv\Dotenv;
 
 Dotenv::createImmutable( dirname( __DIR__ ) )->load();
 
-$capsule = new Capsule;
+$capsule = new Capsule();
 $capsule->addConnection(
 	[
-		'driver' => 'mysql',
-		'host' => 'localhost',
-		'database' => getenv( 'DATABASE' ),
-		'username' => getenv( 'DB_USERNAME' ),
-		'password' => getenv( 'DB_PASSWORD' ),
-		'charset' => 'utf8',
+		'driver'    => 'mysql',
+		'host'      => 'localhost',
+		'database'  => getenv( 'DATABASE' ),
+		'username'  => getenv( 'DB_USERNAME' ),
+		'password'  => getenv( 'DB_PASSWORD' ),
+		'charset'   => 'utf8',
 		'collation' => 'utf8_unicode_ci',
-		'prefix' => '',
+		'prefix'    => '',
 	]
 );
 
@@ -29,11 +29,11 @@ function save_request( APNSRequest $request ): void {
 
 	$capsule->table( 'mobile_push_queue' )->insert(
 		[
-			'token' => $request->getToken(),
-			'payload' => $request->toJSON(),
-			'when' => gmdate( 'Y-m-d H:i:s' ),
+			'token'                 => $request->get_token(),
+			'payload'               => $request->to_json(),
+			'when'                  => gmdate( 'Y-m-d H:i:s' ),
 			'mobile_push_client_id' => get_client_id(),
-			'worker_id' => random_int( 1, 16 ),
+			'worker_id'             => random_int( 1, 16 ),
 		]
 	);
 }
@@ -48,13 +48,13 @@ function save_token( string $token ): void {
 
 	$capsule->table( 'mobile_push_tokens' )->insert(
 		[
-			'token' => $token,
-			'user_id' => random_int( 1, 2147483647 ),
-			'when' => gmdate( 'Y-m-d H:i:s' ),
-			'active' => 1,
-			'device_type' => [ 'apple', 'android' ][ random_int( 0, 1 ) ],
-			'production' => random_int( 0, 1 ),
-			'meta' => '',
+			'token'                 => $token,
+			'user_id'               => random_int( 1, 2147483647 ),
+			'when'                  => gmdate( 'Y-m-d H:i:s' ),
+			'active'                => 1,
+			'device_type'           => [ 'apple', 'android' ][ random_int( 0, 1 ) ],
+			'production'            => random_int( 0, 1 ),
+			'meta'                  => '',
 			'mobile_push_client_id' => get_client_id(),
 		]
 	);

--- a/examples/run-queue.php
+++ b/examples/run-queue.php
@@ -1,5 +1,6 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/db-connect.php';
@@ -10,9 +11,9 @@ $kid = strval( getenv( 'KEY_ID' ) );
 $tid = strval( getenv( 'TEAM_ID' ) );
 $key = strval( getenv( 'KEY' ) );
 
-$auth = new APNSCredentials( $kid, $tid, $key );
+$auth          = new APNSCredentials( $kid, $tid, $key );
 $configuration = APNSConfiguration::production( $auth );
-$configuration->setUserAgent( 'wordpress.com development' );
+$configuration->set_user_agent( 'wordpress.com development' );
 
 $client = new APNSClient( $configuration );
 
@@ -27,7 +28,7 @@ while ( true ) {
 	$time = microtime( true ) - $start;
 	echo PHP_EOL . '=== Fetched ' . count( $pushes ) . ' Messages in ' . $time . ' seconds === ' . PHP_EOL;
 
-	$client->sendRequests( $pushes );
+	$client->send_requests( $pushes );
 
 	$time = microtime( true ) - $start;
 	echo PHP_EOL . '=== Done in ' . $time . ' seconds === ' . PHP_EOL;

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 require_once __DIR__ . '/vendor/autoload.php';
 
@@ -9,27 +10,27 @@ Dotenv::createImmutable( __DIR__ )->load();
 
 echo '=== Push Notification Server ===' . PHP_EOL;
 
-$key_id = strval( getenv( 'KEY_ID' ) );
+$key_id  = strval( getenv( 'KEY_ID' ) );
 $team_id = strval( getenv( 'TEAM_ID' ) );
-$key = strval( getenv( 'KEY' ) );
+$key     = strval( getenv( 'KEY' ) );
 
-$auth = new APNSCredentials( $key_id, $team_id, $key );
+$auth          = new APNSCredentials( $key_id, $team_id, $key );
 $configuration = APNSConfiguration::sandbox( $auth );
-$configuration->setUserAgent( strval( getenv( 'USER_AGENT' ) ) );
+$configuration->set_user_agent( strval( getenv( 'USER_AGENT' ) ) );
 $client = new APNSClient( $configuration );
-$client->setDebug( true );
+$client->set_debug( true );
 
 echo "\t Connected.\n";
-$title = 'Title';
-$message = 'Timestamp ' . time();
+$notification_title   = 'Title';
+$notification_message = 'Timestamp ' . time();
 echo "\t Will send notification with:\n";
-echo "\t - Title: " . $title . PHP_EOL;
-echo "\t - Message: " . $message . PHP_EOL;
+echo "\t - Title: $notification_title \n";
+echo "\t - Message: " . $notification_message . PHP_EOL;
 
-$token = strval( getenv( 'TOKEN' ) );
-$payload = APNSPayload::fromAlert( new APNSAlert( $title, $message ) );
+$token    = strval( getenv( 'TOKEN' ) );
+$payload  = APNSPayload::from_alert( new APNSAlert( $notification_title, $notification_message ) );
 $metadata = new APNSRequestMetadata( strval( getenv( 'TOPIC' ) ) );
-$request = APNSRequest::fromPayload( $payload, $token, $metadata );
+$request  = APNSRequest::from_payload( $payload, $token, $metadata );
 
 $requests = [];
 
@@ -38,16 +39,16 @@ foreach ( range( 0, 2 ) as $i ) {
 	$requests[] = $request;
 }
 
-$responses = $client->sendRequests( $requests );
+$responses = $client->send_requests( $requests );
 
-$notifications_to_retry = [];
+$notifications_to_retry  = [];
 $notifications_to_delete = [];
 
 foreach ( $responses as $response ) {
-	if ( $response->isUnrecoverableError() ) {
-		$notifications_to_delete[] = $response->getUuid();
-	} elseif ( $response->shouldRetry() ) {
-		$notifications_to_retry[] = $response->getUuid();
+	if ( $response->is_unrecoverable_error() ) {
+		$notifications_to_delete[] = $response->get_uuid();
+	} elseif ( $response->should_retry() ) {
+		$notifications_to_retry[] = $response->get_uuid();
 	}
 }
 

--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -10,16 +10,16 @@ class APNSClient {
 	private $configuration;
 
 	public function __construct( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ) {
-		$this->configuration = $configuration;
+		$this->configuration   = $configuration;
 		$this->network_service = $network_service ?? new APNSNetworkService();
 	}
 
-	public static function withConfiguration( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ): self {
+	public static function with_configuration( APNSConfiguration $configuration, ?APNSNetworkService $network_service = null ): self {
 		return new APNSClient( $configuration, $network_service );
 	}
 
-	public function setPortNumber( int $port ): self {
-		$this->network_service->setPort( $port );
+	public function set_port_number( int $port ): self {
+		$this->network_service->set_port( $port );
 		return $this;
 	}
 
@@ -28,30 +28,30 @@ class APNSClient {
 	 *
 	 * @return APNSResponse[]
 	 */
-	public function sendRequests( array $requests ): array {
+	public function send_requests( array $requests ): array {
 		foreach ( $requests as $request ) {
 			assert( get_class( $request ) === APNSRequest::class );
 
-			$url = $request->getUrlForConfiguration( $this->configuration );
-			$headers = $request->getHeadersForConfiguration( $this->configuration );
-			$this->network_service->enqueueRequest( $url, $this->convertRequestHeaders( $headers ), $request->getBody() );
+			$url     = $request->get_url_for_configuration( $this->configuration );
+			$headers = $request->get_headers_for_configuration( $this->configuration );
+			$this->network_service->enqueue_request( $url, $this->convert_request_headers( $headers ), $request->get_body() );
 		}
 
-		return $this->network_service->sendQueuedRequests();
+		return $this->network_service->send_queued_requests();
 	}
 
 	public function close(): self {
-		$this->network_service->closeConnection();
+		$this->network_service->close_connection();
 		return $this;
 	}
 
-	public function setDebug( bool $debug ): self {
-		$this->network_service->setDebug( $debug );
+	public function set_debug( bool $debug ): self {
+		$this->network_service->set_debug( $debug );
 		return $this;
 	}
 
-	public function setCertificateBundlePath( string $path ): self {
-		$this->network_service->setCertificateBundlePath( $path );
+	public function set_certificate_bundle_path( string $path ): self {
+		$this->network_service->set_certificate_bundle_path( $path );
 		return $this;
 	}
 
@@ -62,7 +62,7 @@ class APNSClient {
 	 *
 	 * @return string[]
 	 */
-	private function convertRequestHeaders( array $headers ): array {
+	private function convert_request_headers( array $headers ): array {
 		$_headers = [];
 		foreach ( $headers as $key => $value ) {
 			$_headers[] = $key . ': ' . $value;

--- a/src/helpers/HTTPMessageParser.php
+++ b/src/helpers/HTTPMessageParser.php
@@ -15,7 +15,7 @@ class HTTPMessageParser {
 	/** @var string */
 	private $body = '';
 
-	function __construct( string $text ) {
+	public function __construct( string $text ) {
 
 		if ( empty( $text ) ) {
 			// If we can't make heads or tails of the response, it's probably because of a crashed request – set the defaults and move on
@@ -47,15 +47,15 @@ class HTTPMessageParser {
 		$this->body = trim( implode( PHP_EOL, $lines ) );
 	}
 
-	function getHttpVersion(): string {
+	public function getHttpVersion(): string {
 		return $this->http_version;
 	}
 
-	function getStatusCode(): int {
+	public function getStatusCode(): int {
 		return $this->status_code;
 	}
 
-	function getHeader( string $key ): ?string {
+	public function getHeader( string $key ): ?string {
 		if ( ! isset( $this->headers[ $key ] ) ) {
 			return null;
 		}
@@ -63,7 +63,7 @@ class HTTPMessageParser {
 		return $this->headers[ $key ];
 	}
 
-	function getBody(): string {
+	public function getBody(): string {
 		return $this->body;
 	}
 }

--- a/src/helpers/HTTPMessageParser.php
+++ b/src/helpers/HTTPMessageParser.php
@@ -23,15 +23,15 @@ class HTTPMessageParser {
 		}
 
 		$lines = explode( PHP_EOL, $text );
-		$line = trim( array_shift( $lines ) );
+		$line  = trim( array_shift( $lines ) );
 
 		if ( ! strstr( $line, 'HTTP' ) ) {
 			throw new InvalidArgumentException( 'Invalid Response: HTTP Header Missing in ' . $text );
 		}
 
 		list( $http_version, $status_code ) = explode( ' ', $line, 2 );
-		$this->http_version = $http_version;
-		$this->status_code = intval( $status_code );
+		$this->http_version                 = $http_version;
+		$this->status_code                  = intval( $status_code );
 
 		while ( true ) {
 			$line = trim( array_shift( $lines ) );
@@ -40,22 +40,22 @@ class HTTPMessageParser {
 				break;
 			}
 
-			list( $key, $value ) = explode( ':', $line, 2 );
+			list( $key, $value )   = explode( ':', $line, 2 );
 			$this->headers[ $key ] = trim( $value );
 		}
 
 		$this->body = trim( implode( PHP_EOL, $lines ) );
 	}
 
-	public function getHttpVersion(): string {
+	public function get_http_version(): string {
 		return $this->http_version;
 	}
 
-	public function getStatusCode(): int {
+	public function get_status_code(): int {
 		return $this->status_code;
 	}
 
-	public function getHeader( string $key ): ?string {
+	public function get_header( string $key ): ?string {
 		if ( ! isset( $this->headers[ $key ] ) ) {
 			return null;
 		}
@@ -63,7 +63,7 @@ class HTTPMessageParser {
 		return $this->headers[ $key ];
 	}
 
-	public function getBody(): string {
+	public function get_body(): string {
 		return $this->body;
 	}
 }

--- a/src/model/APNSAlert.php
+++ b/src/model/APNSAlert.php
@@ -109,6 +109,7 @@ class APNSAlert implements JsonSerializable {
 		return $this;
 	}
 
+	/** @psalm-suppress InvalidReturnType */
 	public function jsonSerialize() {
 
 		$data = [
@@ -123,7 +124,7 @@ class APNSAlert implements JsonSerializable {
 		];
 
 		$output = array_filter(
-			$data, function( $value ) {
+			$data, function( $value ): bool {
 				return ! is_null( $value );
 			}
 		);
@@ -133,6 +134,6 @@ class APNSAlert implements JsonSerializable {
 			return $this->title;
 		}
 
-		return $output;
+		return (object) $output;
 	}
 }

--- a/src/model/APNSAlert.php
+++ b/src/model/APNSAlert.php
@@ -30,81 +30,81 @@ class APNSAlert implements JsonSerializable {
 
 	public function __construct( string $title, ?string $body = null ) {
 		$this->title = $title;
-		$this->body = $body;
+		$this->body  = $body;
 	}
 
-	public static function fromString( string $string ): APNSAlert {
+	public static function from_string( string $string ): APNSAlert {
 		return new APNSAlert( $string );
 	}
 
-	public function getTitle(): string {
+	public function get_title(): string {
 		return $this->title;
 	}
 
-	public function setTitle( string $title ): self {
+	public function set_title( string $title ): self {
 		$this->title = $title;
 		return $this;
 	}
 
-	public function getBody(): ?string {
+	public function get_body(): ?string {
 		return $this->body;
 	}
 
-	public function setBody( string $body ): self {
+	public function set_body( string $body ): self {
 		$this->body = $body;
 		return $this;
 	}
 
-	public function getLocalizedTitleKey(): ?string {
+	public function get_localized_title_key(): ?string {
 		return $this->localized_title_key;
 	}
 
-	public function setLocalizedTitleKey( string $key ): self {
+	public function set_localized_title_key( string $key ): self {
 		$this->localized_title_key = $key;
 		return $this;
 	}
 
-	public function getLocalizedTitleArgs(): ?array {
+	public function get_localized_title_args(): ?array {
 		return $this->localized_title_args;
 	}
 
-	public function setLocalizedTitleArgs( array $args ): self {
+	public function set_localized_title_args( array $args ): self {
 		$this->localized_title_args = $args;
 		return $this;
 	}
 
-	public function getLocalizedActionKey(): ?string {
+	public function get_localized_action_key(): ?string {
 		return $this->localized_action_key;
 	}
 
-	public function setLocalizedActionKey( string $key ): self {
+	public function set_localized_action_key( string $key ): self {
 		$this->localized_action_key = $key;
 		return $this;
 	}
 
-	public function getLocalizedMessageKey(): ?string {
+	public function get_localized_message_key(): ?string {
 		return $this->localized_message_key;
 	}
 
-	public function setLocalizedMessageKey( string $key ): self {
+	public function set_localized_message_key( string $key ): self {
 		$this->localized_message_key = $key;
 		return $this;
 	}
 
-	public function getLocalizedMessageArgs(): ?array {
+	public function get_localized_message_args(): ?array {
 		return $this->localized_message_args;
 	}
 
-	public function setLocalizedMessageArgs( array $args ): self {
+	public function set_localized_message_args( array $args ): self {
 		$this->localized_message_args = $args;
 		return $this;
 	}
 
-	public function getLaunchImage(): ?string {
+	public function get_launch_image(): ?string {
 		return $this->launch_image;
 	}
 
-	public function setLaunchImage( string $name ): self {
+	public function set_launch_image( string $name ): self {
 		$this->launch_image = $name;
 		return $this;
 	}
@@ -113,24 +113,25 @@ class APNSAlert implements JsonSerializable {
 	public function jsonSerialize() {
 
 		$data = [
-			'title' => $this->title,
-			'body' => $this->body,
-			'title-loc-key' => $this->localized_title_key,
+			'title'          => $this->title,
+			'body'           => $this->body,
+			'title-loc-key'  => $this->localized_title_key,
 			'title-loc-args' => $this->localized_title_args,
 			'action-loc-key' => $this->localized_action_key,
-			'loc-key' => $this->localized_message_key,
-			'loc-args' => $this->localized_message_args,
-			'launch-image' => $this->launch_image,
+			'loc-key'        => $this->localized_message_key,
+			'loc-args'       => $this->localized_message_args,
+			'launch-image'   => $this->launch_image,
 		];
 
 		$output = array_filter(
-			$data, function( $value ): bool {
+			$data,
+			function( $value ): bool {
 				return ! is_null( $value );
 			}
 		);
 
 		// If only the title is present, return it instead of an object
-		if ( count( $output ) === 1 && array_keys( $output )[0] === 'title' ) {
+		if ( 1 === count( $output ) && 'title' === array_keys( $output )[0] ) {
 			return $this->title;
 		}
 

--- a/src/model/APNSAlert.php
+++ b/src/model/APNSAlert.php
@@ -28,88 +28,88 @@ class APNSAlert implements JsonSerializable {
 	/** @var ?string */
 	protected $launch_image;
 
-	function __construct( string $title, ?string $body = null ) {
+	public function __construct( string $title, ?string $body = null ) {
 		$this->title = $title;
 		$this->body = $body;
 	}
 
-	static function fromString( string $string ): APNSAlert {
+	public static function fromString( string $string ): APNSAlert {
 		return new APNSAlert( $string );
 	}
 
-	function getTitle(): string {
+	public function getTitle(): string {
 		return $this->title;
 	}
 
-	function setTitle( string $title ): self {
+	public function setTitle( string $title ): self {
 		$this->title = $title;
 		return $this;
 	}
 
-	function getBody(): ?string {
+	public function getBody(): ?string {
 		return $this->body;
 	}
 
-	function setBody( string $body ): self {
+	public function setBody( string $body ): self {
 		$this->body = $body;
 		return $this;
 	}
 
-	function getLocalizedTitleKey(): ?string {
+	public function getLocalizedTitleKey(): ?string {
 		return $this->localized_title_key;
 	}
 
-	function setLocalizedTitleKey( string $key ): self {
+	public function setLocalizedTitleKey( string $key ): self {
 		$this->localized_title_key = $key;
 		return $this;
 	}
 
-	function getLocalizedTitleArgs(): ?array {
+	public function getLocalizedTitleArgs(): ?array {
 		return $this->localized_title_args;
 	}
 
-	function setLocalizedTitleArgs( array $args ): self {
+	public function setLocalizedTitleArgs( array $args ): self {
 		$this->localized_title_args = $args;
 		return $this;
 	}
 
-	function getLocalizedActionKey(): ?string {
+	public function getLocalizedActionKey(): ?string {
 		return $this->localized_action_key;
 	}
 
-	function setLocalizedActionKey( string $key ): self {
+	public function setLocalizedActionKey( string $key ): self {
 		$this->localized_action_key = $key;
 		return $this;
 	}
 
-	function getLocalizedMessageKey(): ?string {
+	public function getLocalizedMessageKey(): ?string {
 		return $this->localized_message_key;
 	}
 
-	function setLocalizedMessageKey( string $key ): self {
+	public function setLocalizedMessageKey( string $key ): self {
 		$this->localized_message_key = $key;
 		return $this;
 	}
 
-	function getLocalizedMessageArgs(): ?array {
+	public function getLocalizedMessageArgs(): ?array {
 		return $this->localized_message_args;
 	}
 
-	function setLocalizedMessageArgs( array $args ): self {
+	public function setLocalizedMessageArgs( array $args ): self {
 		$this->localized_message_args = $args;
 		return $this;
 	}
 
-	function getLaunchImage(): ?string {
+	public function getLaunchImage(): ?string {
 		return $this->launch_image;
 	}
 
-	function setLaunchImage( string $name ): self {
+	public function setLaunchImage( string $name ): self {
 		$this->launch_image = $name;
 		return $this;
 	}
 
-	function jsonSerialize() {
+	public function jsonSerialize() {
 
 		$data = [
 			'title' => $this->title,

--- a/src/model/APNSConfiguration.php
+++ b/src/model/APNSConfiguration.php
@@ -40,19 +40,19 @@ class APNSConfiguration {
 		$this->token_factory = $factory ?? new APNSDefaultTokenFactory();
 	}
 
-	static function production( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
+	public static function production( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
 		return new APNSConfiguration( $credentials, APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION, $factory );
 	}
 
-	static function sandbox( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
+	public static function sandbox( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
 		return new APNSConfiguration( $credentials, APNSConfiguration::APNS_ENVIRONMENT_SANDBOX, $factory );
 	}
 
-	function getEnvironment(): string {
+	public function getEnvironment(): string {
 		return $this->environment;
 	}
 
-	function getProviderToken(): string {
+	public function getProviderToken(): string {
 
 		if ( ! is_null( $this->current_token ) && $this->expires > time() ) {
 			return $this->current_token;
@@ -70,23 +70,23 @@ class APNSConfiguration {
 		return $current_token;
 	}
 
-	function getUserAgent(): ?string {
+	public function getUserAgent(): ?string {
 		return $this->user_agent;
 	}
 
-	function setUserAgent( string $user_agent ): self {
+	public function setUserAgent( string $user_agent ): self {
 		$this->user_agent = $user_agent;
 		return $this;
 	}
 
-	function getTokenRefreshInterval(): int {
+	public function getTokenRefreshInterval(): int {
 		return $this->token_refresh_interval;
 	}
 
 	// Must be between 20 and 60 minutes:
 	// Refresh your token no more than once every 20 minutes and no less than once every 60 minutes. APNs rejects any request whose token contains a timestamp that is more than one hour old. Similarly, APNs reports an error if you recreate your tokens more than once every 20 minutes.
 	// Source: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns
-	function setTokenRefreshInterval( int $interval ): self {
+	public function setTokenRefreshInterval( int $interval ): self {
 
 		if ( $interval < 1260 ) {
 			throw new InvalidArgumentException( 'Invalid Token Refresh interval: ' . $interval . '. It must be greater than 21 minutes and less than 59 minutes (specified in seconds)' );
@@ -101,7 +101,7 @@ class APNSConfiguration {
 		return $this;
 	}
 
-	function getEndpoint(): string {
+	public function getEndpoint(): string {
 		if ( $this->environment === APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION ) {
 			return APNSConfiguration::APNS_ENDPOINT_PRODUCTION;
 		}

--- a/src/model/APNSConfiguration.php
+++ b/src/model/APNSConfiguration.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 class APNSConfiguration {
 
 	public const APNS_ENVIRONMENT_PRODUCTION = 'production';
-	public const APNS_ENDPOINT_PRODUCTION = 'https://api.push.apple.com/3/device/';
+	public const APNS_ENDPOINT_PRODUCTION    = 'https://api.push.apple.com/3/device/';
 
 	public const APNS_ENVIRONMENT_SANDBOX = 'sandbox';
-	public const APNS_ENDPOINT_SANDBOX = 'https://api.development.push.apple.com/3/device/';
+	public const APNS_ENDPOINT_SANDBOX    = 'https://api.development.push.apple.com/3/device/';
 
 	/** @var APNSCredentials */
 	private $credentials;
@@ -35,58 +35,58 @@ class APNSConfiguration {
 	private $token_factory;
 
 	protected function __construct( APNSCredentials $credentials, string $environment, ?APNSTokenFactory $factory ) {
-		$this->credentials = $credentials;
-		$this->environment = $environment;
+		$this->credentials   = $credentials;
+		$this->environment   = $environment;
 		$this->token_factory = $factory ?? new APNSDefaultTokenFactory();
 	}
 
 	public static function production( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
-		return new APNSConfiguration( $credentials, APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION, $factory );
+		return new APNSConfiguration( $credentials, self::APNS_ENVIRONMENT_PRODUCTION, $factory );
 	}
 
 	public static function sandbox( APNSCredentials $credentials, ?APNSTokenFactory $factory = null ): self {
-		return new APNSConfiguration( $credentials, APNSConfiguration::APNS_ENVIRONMENT_SANDBOX, $factory );
+		return new APNSConfiguration( $credentials, self::APNS_ENVIRONMENT_SANDBOX, $factory );
 	}
 
-	public function getEnvironment(): string {
+	public function get_environment(): string {
 		return $this->environment;
 	}
 
-	public function getProviderToken(): string {
+	public function get_provider_token(): string {
 
 		if ( ! is_null( $this->current_token ) && $this->expires > time() ) {
 			return $this->current_token;
 		}
 
 		$current_token = $this->token_factory->get_token(
-			$this->credentials->getTeamId(),
-			$this->credentials->getKeyId(),
-			$this->credentials->getKeyBytes()
+			$this->credentials->get_team_id(),
+			$this->credentials->get_key_id(),
+			$this->credentials->get_key_bytes()
 		);
 
-		$this->expires = time() + $this->token_refresh_interval;
+		$this->expires       = time() + $this->token_refresh_interval;
 		$this->current_token = $current_token;
 
 		return $current_token;
 	}
 
-	public function getUserAgent(): ?string {
+	public function get_user_agent(): ?string {
 		return $this->user_agent;
 	}
 
-	public function setUserAgent( string $user_agent ): self {
+	public function set_user_agent( string $user_agent ): self {
 		$this->user_agent = $user_agent;
 		return $this;
 	}
 
-	public function getTokenRefreshInterval(): int {
+	public function get_token_refresh_interval(): int {
 		return $this->token_refresh_interval;
 	}
 
 	// Must be between 20 and 60 minutes:
 	// Refresh your token no more than once every 20 minutes and no less than once every 60 minutes. APNs rejects any request whose token contains a timestamp that is more than one hour old. Similarly, APNs reports an error if you recreate your tokens more than once every 20 minutes.
 	// Source: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns
-	public function setTokenRefreshInterval( int $interval ): self {
+	public function set_token_refresh_interval( int $interval ): self {
 
 		if ( $interval < 1260 ) {
 			throw new InvalidArgumentException( 'Invalid Token Refresh interval: ' . $interval . '. It must be greater than 21 minutes and less than 59 minutes (specified in seconds)' );
@@ -101,13 +101,13 @@ class APNSConfiguration {
 		return $this;
 	}
 
-	public function getEndpoint(): string {
-		if ( $this->environment === APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION ) {
-			return APNSConfiguration::APNS_ENDPOINT_PRODUCTION;
+	public function get_endpoint(): string {
+		if ( self::APNS_ENVIRONMENT_PRODUCTION === $this->environment ) {
+			return self::APNS_ENDPOINT_PRODUCTION;
 		}
 
-		if ( $this->environment === APNSConfiguration::APNS_ENVIRONMENT_SANDBOX ) {
-			return APNSConfiguration::APNS_ENDPOINT_SANDBOX;
+		if ( self::APNS_ENVIRONMENT_SANDBOX === $this->environment ) {
+			return self::APNS_ENDPOINT_SANDBOX;
 		}
 
 		throw new OutOfBoundsException( 'Unable to determine endpoint for environment' );

--- a/src/model/APNSCredentials.php
+++ b/src/model/APNSCredentials.php
@@ -12,7 +12,7 @@ class APNSCredentials {
 	/** @var string */
 	private $key_bytes;
 
-	function __construct( string $key_id, string $team_id, string $key_bytes ) {
+	public function __construct( string $key_id, string $team_id, string $key_bytes ) {
 
 		if ( strlen( $key_id ) !== 10 ) {
 			throw new InvalidArgumentException( 'Invalid key identifier: ' . $key_id . '. Key IDs must be 10 characters long (Found ' . strlen( $key_id ) . ').' );
@@ -27,15 +27,15 @@ class APNSCredentials {
 		$this->key_bytes = $key_bytes;
 	}
 
-	function getKeyId(): string {
+	public function getKeyId(): string {
 		return $this->key_id;
 	}
 
-	function getTeamId(): string {
+	public function getTeamId(): string {
 		return $this->team_id;
 	}
 
-	function getKeyBytes(): string {
+	public function getKeyBytes(): string {
 		return $this->key_bytes;
 	}
 }

--- a/src/model/APNSCredentials.php
+++ b/src/model/APNSCredentials.php
@@ -22,20 +22,20 @@ class APNSCredentials {
 			throw new InvalidArgumentException( 'Invalid team identifier: ' . $team_id . '. Team IDs must be 10 characters long' );
 		}
 
-		$this->key_id = $key_id;
-		$this->team_id = $team_id;
+		$this->key_id    = $key_id;
+		$this->team_id   = $team_id;
 		$this->key_bytes = $key_bytes;
 	}
 
-	public function getKeyId(): string {
+	public function get_key_id(): string {
 		return $this->key_id;
 	}
 
-	public function getTeamId(): string {
+	public function get_team_id(): string {
 		return $this->team_id;
 	}
 
-	public function getKeyBytes(): string {
+	public function get_key_bytes(): string {
 		return $this->key_bytes;
 	}
 }

--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -1,5 +1,6 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
 // Partial list of keys: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363
 class APNSPayload {
@@ -39,8 +40,8 @@ class APNSPayload {
 	 *
 	 * @param string $string
 	 */
-	public static function fromString( string $string ): APNSPayload {
-		return APNSPayload::fromAlert( APNSAlert::fromString( $string ) );
+	public static function from_string( string $string ): APNSPayload {
+		return self::from_alert( APNSAlert::from_string( $string ) );
 	}
 
 	/**
@@ -48,9 +49,9 @@ class APNSPayload {
 	 *
 	 * @param APNSAlert $alert
 	 */
-	public static function fromAlert( APNSAlert $alert ): APNSPayload {
+	public static function from_alert( APNSAlert $alert ): APNSPayload {
 		$payload = new APNSPayload();
-		$payload->setAlert( $alert );
+		$payload->set_alert( $alert );
 		return $payload;
 	}
 
@@ -59,12 +60,12 @@ class APNSPayload {
 	 *
 	 * @param int $count
 	 */
-	public static function fromBadgeCount( int $count ): APNSPayload {
+	public static function from_badge_count( int $count ): APNSPayload {
 		return ( new APNSPayload() )
-			->setBadgeCount( $count );
+			->set_badge_count( $count );
 	}
 
-	public function getAlert(): ?APNSAlert {
+	public function get_alert(): ?APNSAlert {
 		return $this->alert;
 	}
 
@@ -73,7 +74,7 @@ class APNSPayload {
 	 *
 	 * @param string|APNSAlert $alert
 	 */
-	public function setAlert( $alert ): self {
+	public function set_alert( $alert ): self {
 
 		if ( is_string( $alert ) ) {
 			$alert = new APNSAlert( $alert );
@@ -88,11 +89,11 @@ class APNSPayload {
 		return $this;
 	}
 
-	public function getBadgeCount(): ?int {
+	public function get_badge_count(): ?int {
 		return $this->badge;
 	}
 
-	public function setBadgeCount( int $count ): self {
+	public function set_badge_count( int $count ): self {
 		$this->badge = $count;
 		return $this;
 	}
@@ -102,7 +103,7 @@ class APNSPayload {
 	 *
 	 * @return APNSSound|null
 	 */
-	public function getSound(): ?APNSSound {
+	public function get_sound(): ?APNSSound {
 		return $this->sound;
 	}
 
@@ -111,10 +112,10 @@ class APNSPayload {
 	 *
 	 * @param string|APNSSound $sound
 	 */
-	public function setSound( $sound ): self {
+	public function set_sound( $sound ): self {
 
 		if ( is_string( $sound ) ) {
-			$this->sound = APNSSound::fromString( $sound );
+			$this->sound = APNSSound::from_string( $sound );
 			return $this;
 		}
 
@@ -126,74 +127,75 @@ class APNSPayload {
 		throw new InvalidArgumentException( 'Invalid Sound – you must pass either a string or `APNSSound` object.' );
 	}
 
-	public function getIsContentAvailable(): bool {
+	public function get_is_content_available(): bool {
 		return $this->content_available;
 	}
 
-	public function setContentAvailable( bool $content_available ): self {
+	public function set_content_available( bool $content_available ): self {
 		$this->content_available = $content_available;
 		return $this;
 	}
 
-	public function getIsMutableContent(): bool {
+	public function get_is_mutable_content(): bool {
 		return $this->mutable_content;
 	}
 
-	public function setMutableContent( bool $mutable_content ): self {
+	public function set_mutable_content( bool $mutable_content ): self {
 		$this->mutable_content = $mutable_content;
 		return $this;
 	}
 
-	public function getTargetContentId(): ?string {
+	public function get_target_content_id(): ?string {
 		return $this->target_content_id;
 	}
 
-	public function setTargetContentId( string $id ): self {
+	public function set_target_content_id( string $id ): self {
 		$this->target_content_id = $id;
 		return $this;
 	}
 
-	public function getCategory(): ?string {
+	public function get_category(): ?string {
 		return $this->category;
 	}
 
-	public function setCategory( string $category ): self {
+	public function set_category( string $category ): self {
 		$this->category = $category;
 		return $this;
 	}
 
-	public function getThreadId(): ?string {
+	public function get_thread_id(): ?string {
 		return $this->thread_id;
 	}
 
-	public function setThreadId( string $id ): self {
+	public function set_thread_id( string $id ): self {
 		$this->thread_id = $id;
 		return $this;
 	}
 
-	public function getCustomData(): array {
+	public function get_custom_data(): array {
 		return $this->custom;
 	}
 
-	public function setCustomData( array $data ): self {
+	public function set_custom_data( array $data ): self {
 		$this->custom = $data;
 		return $this;
 	}
 
-	public function toJSON(): string {
+	public function to_json(): string {
 		$payload_data = [
-			'alert' => $this->alert,
-			'badge' => $this->badge,
-			'sound' => $this->sound,
+			'alert'             => $this->alert,
+			'badge'             => $this->badge,
+			'sound'             => $this->sound,
 			'content-available' => $this->content_available ? 1 : null,
-			'mutable-content' => $this->mutable_content ? 1 : null,
+			'mutable-content'   => $this->mutable_content ? 1 : null,
 			'target-content-id' => $this->target_content_id,
-			'category' => $this->category,
-			'thread-id' => $this->thread_id,
+			'category'          => $this->category,
+			'thread-id'         => $this->thread_id,
 		];
 
 		$payload_data = array_filter(
-			$payload_data, function( $value ): bool {
+			$payload_data,
+			function( $value ): bool {
 				return ! is_null( $value );
 			}
 		);

--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -32,14 +32,14 @@ class APNSPayload {
 	private $custom = [];
 
 	// This class can be set up too many different ways to have any kind of shared constructor, so we'll explicitly define an empty one
-	function __construct() { }
+	private function __construct() { }
 
 	/**
 	 * Create an APNSPayload from the provided string
 	 *
 	 * @param string $string
 	 */
-	static function fromString( string $string ): APNSPayload {
+	public static function fromString( string $string ): APNSPayload {
 		return APNSPayload::fromAlert( APNSAlert::fromString( $string ) );
 	}
 
@@ -48,7 +48,7 @@ class APNSPayload {
 	 *
 	 * @param APNSAlert $alert
 	 */
-	static function fromAlert( APNSAlert $alert ): APNSPayload {
+	public static function fromAlert( APNSAlert $alert ): APNSPayload {
 		$payload = new APNSPayload();
 		$payload->setAlert( $alert );
 		return $payload;
@@ -59,12 +59,12 @@ class APNSPayload {
 	 *
 	 * @param int $count
 	 */
-	static function fromBadgeCount( int $count ): APNSPayload {
+	public static function fromBadgeCount( int $count ): APNSPayload {
 		return ( new APNSPayload() )
 			->setBadgeCount( $count );
 	}
 
-	function getAlert(): ?APNSAlert {
+	public function getAlert(): ?APNSAlert {
 		return $this->alert;
 	}
 
@@ -73,7 +73,7 @@ class APNSPayload {
 	 *
 	 * @param string|APNSAlert $alert
 	 */
-	function setAlert( $alert ): self {
+	public function setAlert( $alert ): self {
 
 		if ( is_string( $alert ) ) {
 			$alert = new APNSAlert( $alert );
@@ -88,11 +88,11 @@ class APNSPayload {
 		return $this;
 	}
 
-	function getBadgeCount(): ?int {
+	public function getBadgeCount(): ?int {
 		return $this->badge;
 	}
 
-	function setBadgeCount( int $count ): self {
+	public function setBadgeCount( int $count ): self {
 		$this->badge = $count;
 		return $this;
 	}
@@ -102,7 +102,7 @@ class APNSPayload {
 	 *
 	 * @return APNSSound|null
 	 */
-	function getSound(): ?APNSSound {
+	public function getSound(): ?APNSSound {
 		return $this->sound;
 	}
 
@@ -111,7 +111,7 @@ class APNSPayload {
 	 *
 	 * @param string|APNSSound $sound
 	 */
-	function setSound( $sound ): self {
+	public function setSound( $sound ): self {
 
 		if ( is_string( $sound ) ) {
 			$this->sound = APNSSound::fromString( $sound );
@@ -126,56 +126,56 @@ class APNSPayload {
 		throw new InvalidArgumentException( 'Invalid Sound – you must pass either a string or `APNSSound` object.' );
 	}
 
-	function getIsContentAvailable(): bool {
+	public function getIsContentAvailable(): bool {
 		return $this->content_available;
 	}
 
-	function setContentAvailable( bool $content_available ): self {
+	public function setContentAvailable( bool $content_available ): self {
 		$this->content_available = $content_available;
 		return $this;
 	}
 
-	function getIsMutableContent(): bool {
+	public function getIsMutableContent(): bool {
 		return $this->mutable_content;
 	}
 
-	function setMutableContent( bool $mutable_content ): self {
+	public function setMutableContent( bool $mutable_content ): self {
 		$this->mutable_content = $mutable_content;
 		return $this;
 	}
 
-	function getTargetContentId(): ?string {
+	public function getTargetContentId(): ?string {
 		return $this->target_content_id;
 	}
 
-	function setTargetContentId( string $id ): self {
+	public function setTargetContentId( string $id ): self {
 		$this->target_content_id = $id;
 		return $this;
 	}
 
-	function getCategory(): ?string {
+	public function getCategory(): ?string {
 		return $this->category;
 	}
 
-	function setCategory( string $category ): self {
+	public function setCategory( string $category ): self {
 		$this->category = $category;
 		return $this;
 	}
 
-	function getThreadId(): ?string {
+	public function getThreadId(): ?string {
 		return $this->thread_id;
 	}
 
-	function setThreadId( string $id ): self {
+	public function setThreadId( string $id ): self {
 		$this->thread_id = $id;
 		return $this;
 	}
 
-	function getCustomData(): array {
+	public function getCustomData(): array {
 		return $this->custom;
 	}
 
-	function setCustomData( array $data ): self {
+	public function setCustomData( array $data ): self {
 		$this->custom = $data;
 		return $this;
 	}

--- a/src/model/APNSPayload.php
+++ b/src/model/APNSPayload.php
@@ -193,7 +193,7 @@ class APNSPayload {
 		];
 
 		$payload_data = array_filter(
-			$payload_data, function( $value ) {
+			$payload_data, function( $value ): bool {
 				return ! is_null( $value );
 			}
 		);

--- a/src/model/APNSPriority.php
+++ b/src/model/APNSPriority.php
@@ -5,12 +5,14 @@ class APNSPriority {
 	public const IMMEDIATE = 10;
 	public const THROTTLED = 5;
 
-	public static function isValid( int $key ): bool {
+	public static function is_valid( int $key ): bool {
 		return in_array(
-			$key, [
-				APNSPriority::IMMEDIATE,
-				APNSPriority::THROTTLED,
-			], true
+			$key,
+			[
+				self::IMMEDIATE,
+				self::THROTTLED,
+			],
+			true
 		);
 	}
 }

--- a/src/model/APNSPushType.php
+++ b/src/model/APNSPushType.php
@@ -2,21 +2,23 @@
 declare( strict_types = 1 );
 
 class APNSPushType {
-	public const ALERT = 'alert';
-	public const BACKGROUND = 'background';
-	public const MDM = 'mdm';
-	public const VOIP = 'voip';
+	public const ALERT        = 'alert';
+	public const BACKGROUND   = 'background';
+	public const MDM          = 'mdm';
+	public const VOIP         = 'voip';
 	public const FILEPROVIDER = 'fileprovider';
 
-	public static function isValid( string $key ): bool {
+	public static function is_valid( string $key ): bool {
 		return in_array(
-			$key, [
-				APNSPushType::ALERT,
-				APNSPushType::BACKGROUND,
-				APNSPushType::MDM,
-				APNSPushType::VOIP,
-				APNSPushType::FILEPROVIDER,
-			], true
+			$key,
+			[
+				self::ALERT,
+				self::BACKGROUND,
+				self::MDM,
+				self::VOIP,
+				self::FILEPROVIDER,
+			],
+			true
 		);
 	}
 }

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -1,5 +1,6 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
 class APNSRequest {
 
@@ -12,39 +13,39 @@ class APNSRequest {
 	// The device token
 	private $token;
 
-	public static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
-		$payload = APNSPayload::fromString( $payload );
-		return new APNSRequest( $payload->toJSON(), $token, $metadata );
+	public static function from_string( string $payload, string $token, APNSRequestMetadata $metadata ): self {
+		$payload = APNSPayload::from_string( $payload );
+		return new APNSRequest( $payload->to_json(), $token, $metadata );
 	}
 
-	public static function fromPayload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
-		return new APNSRequest( $payload->toJSON(), $token, $metadata );
+	public static function from_payload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
+		return new APNSRequest( $payload->to_json(), $token, $metadata );
 	}
 
 	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata ) {
-		$this->body = $payload;
-		$this->token = $token;
+		$this->body     = $payload;
+		$this->token    = $token;
 		$this->metadata = $metadata;
 	}
 
-	public function getToken(): string {
+	public function get_token(): string {
 		return $this->token;
 	}
 
-	public function getMetadata(): APNSRequestMetadata {
+	public function get_metadata(): APNSRequestMetadata {
 		return $this->metadata;
 	}
 
-	public function getBody(): string {
+	public function get_body(): string {
 		return $this->body;
 	}
 
-	public function getUuid(): string {
-		return $this->metadata->getUuid();
+	public function get_uuid(): string {
+		return $this->metadata->get_uuid();
 	}
 
-	public function getUrlForConfiguration( APNSConfiguration $configuration ): string {
-		return $configuration->getEndpoint() . $this->token;
+	public function get_url_for_configuration( APNSConfiguration $configuration ): string {
+		return $configuration->get_endpoint() . $this->token;
 	}
 
 	/**
@@ -52,37 +53,37 @@ class APNSRequest {
 	 *
 	 * @psalm-return array<string, string>
 	 */
-	public function getHeadersForConfiguration( APNSConfiguration $configuration ): array {
+	public function get_headers_for_configuration( APNSConfiguration $configuration ): array {
 
 		$headers = [
 			// Typical HTTP Headers
-			'authorization' => 'bearer ' . $configuration->getProviderToken(),
-			'content-type' => 'application/json',
-			'content-length' => strval( strlen( $this->body ) ),
+			'authorization'   => 'bearer ' . $configuration->get_provider_token(),
+			'content-type'    => 'application/json',
+			'content-length'  => strval( strlen( $this->body ) ),
 
 			// Apple-specific Required Headers
-			'apns-expiration' => strval( $this->metadata->getExpirationTimestamp() ),
-			'apns-push-type' => $this->metadata->getPushType(),
-			'apns-topic' => $this->metadata->getTopic(),
+			'apns-expiration' => strval( $this->metadata->get_expiration_timestamp() ),
+			'apns-push-type'  => $this->metadata->get_push_type(),
+			'apns-topic'      => $this->metadata->get_topic(),
 		];
 
 		// A developer-provided user agent is optional, and if it's not set, the transport mechanism can manually specify this
-		if ( ! is_null( $configuration->getUserAgent() ) ) {
-			$headers['user-agent'] = $configuration->getUserAgent() ?? 'unknown';
+		if ( ! is_null( $configuration->get_user_agent() ) ) {
+			$headers['user-agent'] = $configuration->get_user_agent() ?? 'unknown';
 		}
 
 		// Only include priority if it has been specifically set by the developer
-		if ( $this->metadata->getPriority() !== 10 ) {
-			$headers['apns-priority'] = strval( $this->metadata->getPriority() );
+		if ( $this->metadata->get_priority() !== 10 ) {
+			$headers['apns-priority'] = strval( $this->metadata->get_priority() );
 		}
 
-		if ( ! is_null( $this->metadata->getUuid() ) ) {
-			$headers['apns-id'] = $this->metadata->getUuid();
+		if ( ! is_null( $this->metadata->get_uuid() ) ) {
+			$headers['apns-id'] = $this->metadata->get_uuid();
 		}
 
 		// Collapse identifier is optional – we won't set it unless it's present, because an empty value is a valid collapse identifer
 		// and this would group notifications together in a way we don't want
-		$collapse_identifier = $this->metadata->getCollapseIdentifier();
+		$collapse_identifier = $this->metadata->get_collapse_identifier();
 		if ( ! is_null( $collapse_identifier ) ) {
 			$headers['apns-collapse-id'] = $collapse_identifier;
 		}
@@ -90,17 +91,17 @@ class APNSRequest {
 		return $headers;
 	}
 
-	public function toJSON(): string {
+	public function to_json(): string {
 		return json_encode(
 			[
-				'payload' => $this->body,
-				'token' => $this->token,
-				'metadata' => $this->metadata->toJSON(),
+				'payload'  => $this->body,
+				'token'    => $this->token,
+				'metadata' => $this->metadata->to_json(),
 			]
 		);
 	}
 
-	public static function fromJSON( string $data ): self {
+	public static function from_json( string $data ): self {
 		$object = (object) json_decode( $data, false, 512, JSON_THROW_ON_ERROR );
 
 		if ( ! property_exists( $object, 'payload' ) || is_null( $object->payload ) || ! is_string( $object->payload ) ) {
@@ -115,6 +116,6 @@ class APNSRequest {
 			throw new InvalidArgumentException( 'Unable to unserialize object – `metadata` is invalid' );
 		}
 
-		return new APNSRequest( $object->payload, $object->token, APNSRequestMetadata::fromJSON( $object->metadata ) );
+		return new APNSRequest( $object->payload, $object->token, APNSRequestMetadata::from_json( $object->metadata ) );
 	}
 }

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -12,12 +12,12 @@ class APNSRequest {
 	// The device token
 	private $token;
 
-	static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
+	public static function fromString( string $payload, string $token, APNSRequestMetadata $metadata ): self {
 		$payload = APNSPayload::fromString( $payload );
 		return new APNSRequest( $payload->toJSON(), $token, $metadata );
 	}
 
-	static function fromPayload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
+	public static function fromPayload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
 		return new APNSRequest( $payload->toJSON(), $token, $metadata );
 	}
 
@@ -27,23 +27,23 @@ class APNSRequest {
 		$this->metadata = $metadata;
 	}
 
-	function getToken(): string {
+	public function getToken(): string {
 		return $this->token;
 	}
 
-	function getMetadata(): APNSRequestMetadata {
+	public function getMetadata(): APNSRequestMetadata {
 		return $this->metadata;
 	}
 
-	function getBody(): string {
+	public function getBody(): string {
 		return $this->body;
 	}
 
-	function getUuid(): string {
+	public function getUuid(): string {
 		return $this->metadata->getUuid();
 	}
 
-	function getUrlForConfiguration( APNSConfiguration $configuration ): string {
+	public function getUrlForConfiguration( APNSConfiguration $configuration ): string {
 		return $configuration->getEndpoint() . $this->token;
 	}
 
@@ -52,7 +52,7 @@ class APNSRequest {
 	 *
 	 * @psalm-return array<string, string>
 	 */
-	function getHeadersForConfiguration( APNSConfiguration $configuration ): array {
+	public function getHeadersForConfiguration( APNSConfiguration $configuration ): array {
 
 		$headers = [
 			// Typical HTTP Headers

--- a/src/model/APNSRequestMetadata.php
+++ b/src/model/APNSRequestMetadata.php
@@ -21,7 +21,7 @@ class APNSRequestMetadata {
 	/** @var string */
 	private $uuid;
 
-	function __construct( string $topic, ?string $uuid = null ) {
+	public function __construct( string $topic, ?string $uuid = null ) {
 		$this->topic = $topic;
 		$this->uuid = $uuid ?? $this->generate_uuid();
 	}
@@ -30,11 +30,11 @@ class APNSRequestMetadata {
 		return new APNSRequestMetadata( $topic );
 	}
 
-	function getTopic(): string {
+	public function getTopic(): string {
 		return $this->topic;
 	}
 
-	function setTopic( string $topic ): self {
+	public function setTopic( string $topic ): self {
 
 		if ( empty( trim( $topic ) ) ) {
 			throw new InvalidArgumentException( 'The topic ' . $topic . ' must not be empty' );
@@ -44,11 +44,11 @@ class APNSRequestMetadata {
 		return $this;
 	}
 
-	function getPushType(): string {
+	public function getPushType(): string {
 		return $this->push_type;
 	}
 
-	function setPushType( string $type ): self {
+	public function setPushType( string $type ): self {
 		if ( ! APNSPushType::isValid( $type ) ) {
 			throw new InvalidArgumentException( 'Invalid Push Type: ' . $type );
 		}
@@ -64,7 +64,7 @@ class APNSRequestMetadata {
 	 *
 	 * @return int
 	 */
-	function getExpirationTimestamp(): int {
+	public function getExpirationTimestamp(): int {
 		return $this->expiration_timestamp;
 	}
 
@@ -75,12 +75,12 @@ class APNSRequestMetadata {
 	 * If this value is nonzero, APNs stores the notification and tries to deliver it at least once, repeating the attempt as needed if it is unable to deliver the notification the first time. If the value is 0, APNs treats the notification as if it expires immediately and does not store the notification or attempt to redeliver it.
 	 * @return APNSRequestMetadata
 	 */
-	function setExpirationTimestamp( int $timestamp ): self {
+	public function setExpirationTimestamp( int $timestamp ): self {
 		$this->expiration_timestamp = $timestamp;
 		return $this;
 	}
 
-	function getPriority(): int {
+	public function getPriority(): int {
 		return $this->priority;
 	}
 
@@ -93,7 +93,7 @@ class APNSRequestMetadata {
 	 *
 	 * @return APNSRequestMetadata
 	 */
-	function setNormalPriority(): self {
+	public function setNormalPriority(): self {
 		$this->priority = APNSPriority::IMMEDIATE;
 		return $this;
 	}
@@ -105,12 +105,12 @@ class APNSRequestMetadata {
 	 *
 	 * @return APNSRequestMetadata
 	 */
-	function setLowPriority(): self {
+	public function setLowPriority(): self {
 		$this->priority = APNSPriority::THROTTLED;
 		return $this;
 	}
 
-	function getCollapseIdentifier(): ?string {
+	public function getCollapseIdentifier(): ?string {
 		return $this->collapse_identifier;
 	}
 
@@ -121,7 +121,7 @@ class APNSRequestMetadata {
 	 * The length of this identifier must not exceed 64 bytes.
 	 * @return self
 	 */
-	function setCollapseIdentifier( string $identifier ): self {
+	public function setCollapseIdentifier( string $identifier ): self {
 
 		if ( strlen( $identifier ) > 64 ) {
 			throw new InvalidArgumentException( 'The collapse identifier ' . $identifier . ' is greater than 64 byes in length' );
@@ -131,11 +131,11 @@ class APNSRequestMetadata {
 		return $this;
 	}
 
-	function getUuid(): string {
+	public function getUuid(): string {
 		return $this->uuid;
 	}
 
-	function setUuid( string $uuid ): self {
+	public function setUuid( string $uuid ): self {
 		$this->uuid = $uuid;
 		return $this;
 	}

--- a/src/model/APNSRequestMetadata.php
+++ b/src/model/APNSRequestMetadata.php
@@ -1,5 +1,6 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
 class APNSRequestMetadata {
 
@@ -23,18 +24,18 @@ class APNSRequestMetadata {
 
 	public function __construct( string $topic, ?string $uuid = null ) {
 		$this->topic = $topic;
-		$this->uuid = $uuid ?? $this->generate_uuid();
+		$this->uuid  = $uuid ?? $this->generate_uuid();
 	}
 
-	public static function withTopic( string $topic ): self {
+	public static function with_topic( string $topic ): self {
 		return new APNSRequestMetadata( $topic );
 	}
 
-	public function getTopic(): string {
+	public function get_topic(): string {
 		return $this->topic;
 	}
 
-	public function setTopic( string $topic ): self {
+	public function set_topic( string $topic ): self {
 
 		if ( empty( trim( $topic ) ) ) {
 			throw new InvalidArgumentException( 'The topic ' . $topic . ' must not be empty' );
@@ -44,12 +45,12 @@ class APNSRequestMetadata {
 		return $this;
 	}
 
-	public function getPushType(): string {
+	public function get_push_type(): string {
 		return $this->push_type;
 	}
 
-	public function setPushType( string $type ): self {
-		if ( ! APNSPushType::isValid( $type ) ) {
+	public function set_push_type( string $type ): self {
+		if ( ! APNSPushType::is_valid( $type ) ) {
 			throw new InvalidArgumentException( 'Invalid Push Type: ' . $type );
 		}
 
@@ -64,7 +65,7 @@ class APNSRequestMetadata {
 	 *
 	 * @return int
 	 */
-	public function getExpirationTimestamp(): int {
+	public function get_expiration_timestamp(): int {
 		return $this->expiration_timestamp;
 	}
 
@@ -75,12 +76,12 @@ class APNSRequestMetadata {
 	 * If this value is nonzero, APNs stores the notification and tries to deliver it at least once, repeating the attempt as needed if it is unable to deliver the notification the first time. If the value is 0, APNs treats the notification as if it expires immediately and does not store the notification or attempt to redeliver it.
 	 * @return APNSRequestMetadata
 	 */
-	public function setExpirationTimestamp( int $timestamp ): self {
+	public function set_expiration_timestamp( int $timestamp ): self {
 		$this->expiration_timestamp = $timestamp;
 		return $this;
 	}
 
-	public function getPriority(): int {
+	public function get_priority(): int {
 		return $this->priority;
 	}
 
@@ -93,7 +94,7 @@ class APNSRequestMetadata {
 	 *
 	 * @return APNSRequestMetadata
 	 */
-	public function setNormalPriority(): self {
+	public function set_normal_priority(): self {
 		$this->priority = APNSPriority::IMMEDIATE;
 		return $this;
 	}
@@ -105,12 +106,12 @@ class APNSRequestMetadata {
 	 *
 	 * @return APNSRequestMetadata
 	 */
-	public function setLowPriority(): self {
+	public function set_low_priority(): self {
 		$this->priority = APNSPriority::THROTTLED;
 		return $this;
 	}
 
-	public function getCollapseIdentifier(): ?string {
+	public function get_collapse_identifier(): ?string {
 		return $this->collapse_identifier;
 	}
 
@@ -119,9 +120,10 @@ class APNSRequestMetadata {
 	 *
 	 * Multiple notifications with the same collapse identifier are displayed to the user as a single notification.
 	 * The length of this identifier must not exceed 64 bytes.
+	 *
 	 * @return self
 	 */
-	public function setCollapseIdentifier( string $identifier ): self {
+	public function set_collapse_identifier( string $identifier ): self {
 
 		if ( strlen( $identifier ) > 64 ) {
 			throw new InvalidArgumentException( 'The collapse identifier ' . $identifier . ' is greater than 64 byes in length' );
@@ -131,45 +133,45 @@ class APNSRequestMetadata {
 		return $this;
 	}
 
-	public function getUuid(): string {
+	public function get_uuid(): string {
 		return $this->uuid;
 	}
 
-	public function setUuid( string $uuid ): self {
+	public function set_uuid( string $uuid ): self {
 		$this->uuid = $uuid;
 		return $this;
 	}
 
-	// Copied from WordPress
+	// Adapted from WordPress
 	private function generate_uuid(): string {
 		return sprintf(
 			'%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-			mt_rand( 0, 0xffff ),
-			mt_rand( 0, 0xffff ),
-			mt_rand( 0, 0xffff ),
-			mt_rand( 0, 0x0fff ) | 0x4000,
-			mt_rand( 0, 0x3fff ) | 0x8000,
-			mt_rand( 0, 0xffff ),
-			mt_rand( 0, 0xffff ),
-			mt_rand( 0, 0xffff )
+			random_int( 0, 0xffff ),
+			random_int( 0, 0xffff ),
+			random_int( 0, 0xffff ),
+			random_int( 0, 0x0fff ) | 0x4000,
+			random_int( 0, 0x3fff ) | 0x8000,
+			random_int( 0, 0xffff ),
+			random_int( 0, 0xffff ),
+			random_int( 0, 0xffff )
 		);
 	}
 
-	public function toJSON(): string {
+	public function to_json(): string {
 		$object = [
 			'topic' => $this->topic,
-			'uuid' => $this->uuid,
+			'uuid'  => $this->uuid,
 		];
 
-		if ( $this->push_type !== APNSPushType::ALERT ) {
+		if ( APNSPushType::ALERT !== $this->push_type ) {
 			$object['push_type'] = $this->push_type;
 		}
 
-		if ( $this->expiration_timestamp !== 0 ) {
+		if ( 0 !== $this->expiration_timestamp ) {
 			$object['expiration_timestamp'] = $this->expiration_timestamp;
 		}
 
-		if ( $this->priority !== APNSPriority::IMMEDIATE ) {
+		if ( APNSPriority::IMMEDIATE !== $this->priority ) {
 			$object['priority'] = $this->priority;
 		}
 
@@ -180,7 +182,7 @@ class APNSRequestMetadata {
 		return json_encode( $object );
 	}
 
-	public static function fromJSON( string $data ): self {
+	public static function from_json( string $data ): self {
 		$object = (object) json_decode( $data, false, 512, JSON_THROW_ON_ERROR );
 
 		if ( ! property_exists( $object, 'topic' ) || is_null( $object->topic ) || ! is_string( $object->topic ) ) {
@@ -194,27 +196,27 @@ class APNSRequestMetadata {
 		$metadata = new APNSRequestMetadata( $object->topic, $object->uuid );
 
 		if ( property_exists( $object, 'push_type' ) && ! is_null( $object->push_type ) && is_string( $object->push_type ) ) {
-			$metadata->setPushType( $object->push_type );
+			$metadata->set_push_type( $object->push_type );
 		}
 
 		if ( property_exists( $object, 'expiration_timestamp' ) && ! is_null( $object->expiration_timestamp ) && is_numeric( $object->expiration_timestamp ) ) {
-			$metadata->setExpirationTimestamp( intval( $object->expiration_timestamp ) );
+			$metadata->set_expiration_timestamp( intval( $object->expiration_timestamp ) );
 		}
 
 		if ( property_exists( $object, 'priority' ) && ! is_null( $object->priority ) && is_numeric( $object->priority ) ) {
-			if ( ! APNSPriority::isValid( intval( $object->priority ) ) ) {
+			if ( ! APNSPriority::is_valid( intval( $object->priority ) ) ) {
 				throw new InvalidArgumentException( 'Unable to unserialize object – `priority` is invalid' );
 			}
 
-			if ( $object->priority === APNSPriority::IMMEDIATE ) {
-				$metadata->setNormalPriority();
-			} elseif ( $object->priority === APNSPriority::THROTTLED ) {
-				$metadata->setLowPriority();
+			if ( APNSPriority::IMMEDIATE === $object->priority ) {
+				$metadata->set_normal_priority();
+			} elseif ( APNSPriority::THROTTLED === $object->priority ) {
+				$metadata->set_low_priority();
 			}
 		}
 
 		if ( property_exists( $object, 'collapse_identifier' ) && ! is_null( $object->collapse_identifier ) && is_string( $object->collapse_identifier ) ) {
-			$metadata->setCollapseIdentifier( $object->collapse_identifier );
+			$metadata->set_collapse_identifier( $object->collapse_identifier );
 		}
 
 		return $metadata;

--- a/src/model/APNSResponse.php
+++ b/src/model/APNSResponse.php
@@ -17,16 +17,16 @@ class APNSResponse {
 
 	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics ) {
 		$this->status_code = $status_code;
-		$this->metrics = $metrics;
+		$this->metrics     = $metrics;
 
-		$parser = new HTTPMessageParser( $response_text );
-		$this->uuid = $parser->getHeader( 'apns-id' ) ?? 'Not Available';
+		$parser     = new HTTPMessageParser( $response_text );
+		$this->uuid = $parser->get_header( 'apns-id' ) ?? 'Not Available';
 
-		if ( $this->isError() ) {
+		if ( $this->is_error() ) {
 			if ( ! empty( $response_text ) ) {
-				$body = (object) json_decode( $parser->getBody(), false, 512, JSON_THROW_ON_ERROR );
+				$body = (object) json_decode( $parser->get_body(), false, 512, JSON_THROW_ON_ERROR );
 				/** @var string */
-				$reason = $body->reason;
+				$reason              = $body->reason;
 				$this->error_message = $reason;
 			} else {
 				$this->error_message = '';
@@ -34,44 +34,46 @@ class APNSResponse {
 		}
 	}
 
-	public function getUuid(): string {
+	public function get_uuid(): string {
 		return $this->uuid;
 	}
 
-	public function getStatusCode(): int {
+	public function get_status_code(): int {
 		return $this->status_code;
 	}
 
-	public function isError(): bool {
-		return $this->status_code !== 200;
+	public function is_error(): bool {
+		return 200 !== $this->status_code;
 	}
 
-	public function getErrorMessage(): ?string {
+	public function get_error_message(): ?string {
 		return $this->error_message;
 	}
 
-	public function isUnrecoverableError(): bool {
+	public function is_unrecoverable_error(): bool {
 		return in_array(
-			$this->status_code, [
+			$this->status_code,
+			[
 				400,    // Bad request (invalid data)
 				403,    // Authentication Token Error
 				404,    // Invalid Device Token (Bad URL Path)
 				405,    // Invalid HTTP Request Type
 				410,    // The device token is no longer active
 				413,    // Notification payload was too large
-			], true
+			],
+			true
 		);
 	}
 
-	public function shouldUnsubscribeDevice(): bool {
-		return $this->status_code === 410;
+	public function should_unsubscribe_device(): bool {
+		return 410 === $this->status_code;
 	}
 
-	public function shouldRetry(): bool {
-		return $this->status_code === 429 || $this->isServerError() || $this->status_code === 0;
+	public function should_retry(): bool {
+		return 429 === $this->status_code || $this->is_server_error() || 0 === $this->status_code;
 	}
 
-	public function isServerError(): bool {
-		return $this->status_code >= 500;
+	public function is_server_error(): bool {
+		return 500 <= $this->status_code;
 	}
 }

--- a/src/model/APNSResponse.php
+++ b/src/model/APNSResponse.php
@@ -15,7 +15,7 @@ class APNSResponse {
 	/** @var APNSResponseMetrics */
 	private $metrics;
 
-	function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics ) {
+	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics ) {
 		$this->status_code = $status_code;
 		$this->metrics = $metrics;
 
@@ -34,23 +34,23 @@ class APNSResponse {
 		}
 	}
 
-	function getUuid(): string {
+	public function getUuid(): string {
 		return $this->uuid;
 	}
 
-	function getStatusCode(): int {
+	public function getStatusCode(): int {
 		return $this->status_code;
 	}
 
-	function isError(): bool {
+	public function isError(): bool {
 		return $this->status_code !== 200;
 	}
 
-	function getErrorMessage(): ?string {
+	public function getErrorMessage(): ?string {
 		return $this->error_message;
 	}
 
-	function isUnrecoverableError(): bool {
+	public function isUnrecoverableError(): bool {
 		return in_array(
 			$this->status_code, [
 				400,    // Bad request (invalid data)
@@ -63,15 +63,15 @@ class APNSResponse {
 		);
 	}
 
-	function shouldUnsubscribeDevice(): bool {
+	public function shouldUnsubscribeDevice(): bool {
 		return $this->status_code === 410;
 	}
 
-	function shouldRetry(): bool {
+	public function shouldRetry(): bool {
 		return $this->status_code === 429 || $this->isServerError() || $this->status_code === 0;
 	}
 
-	function isServerError(): bool {
+	public function isServerError(): bool {
 		return $this->status_code >= 500;
 	}
 }

--- a/src/model/APNSResponseMetrics.php
+++ b/src/model/APNSResponseMetrics.php
@@ -6,7 +6,7 @@ class APNSResponseMetrics {
 	private $request_size;
 	private $request_time;
 
-	function __construct( int $request_size = 0, int $request_time = 0 ) {
+	public function __construct( int $request_size = 0, int $request_time = 0 ) {
 		$this->request_size = $request_size;
 		$this->request_time = $request_time;
 	}

--- a/src/model/APNSSound.php
+++ b/src/model/APNSSound.php
@@ -13,39 +13,39 @@ class APNSSound implements JsonSerializable {
 	/** @var float */
 	private $volume;
 
-	function __construct( string $name, float $volume = 1.0, bool $is_critical = false ) {
+	public function __construct( string $name, float $volume = 1.0, bool $is_critical = false ) {
 		$this->name = $name;
 		$this->volume = $volume;
 		$this->setIsCritical( $is_critical );
 	}
 
-	static function fromString( string $name ): APNSSound {
+	public static function fromString( string $name ): APNSSound {
 		return new APNSSound( $name );
 	}
 
-	function getIsCritical(): bool {
+	public function getIsCritical(): bool {
 		return $this->is_critical;
 	}
 
-	function setIsCritical( bool $is_critical ): self {
+	public function setIsCritical( bool $is_critical ): self {
 		$this->is_critical = $is_critical;
 		return $this;
 	}
 
-	function getName(): string {
+	public function getName(): string {
 		return $this->name;
 	}
 
-	function setName( string $name ): self {
+	public function setName( string $name ): self {
 		$this->name = $name;
 		return $this;
 	}
 
-	function getVolume(): float {
+	public function getVolume(): float {
 		return $this->volume;
 	}
 
-	function setVolume( float $volume ): self {
+	public function setVolume( float $volume ): self {
 		if ( $volume < 0 || $volume > 1.0 ) {
 			throw new InvalidArgumentException( 'Invalid sound volume: ' . $volume . '. Valid volume levels are between 0.0 and 1.0' );
 		}
@@ -54,7 +54,7 @@ class APNSSound implements JsonSerializable {
 		return $this;
 	}
 
-	function jsonSerialize() {
+	public function jsonSerialize() {
 
 		// If the volume and `critical` flags haven't been modified, we can just send the filename to save space
 		if ( 1.0 === $this->volume && false === $this->is_critical ) {

--- a/src/model/APNSSound.php
+++ b/src/model/APNSSound.php
@@ -54,6 +54,7 @@ class APNSSound implements JsonSerializable {
 		return $this;
 	}
 
+	/** @psalm-suppress InvalidReturnType */
 	public function jsonSerialize() {
 
 		// If the volume and `critical` flags haven't been modified, we can just send the filename to save space

--- a/src/model/APNSSound.php
+++ b/src/model/APNSSound.php
@@ -14,38 +14,38 @@ class APNSSound implements JsonSerializable {
 	private $volume;
 
 	public function __construct( string $name, float $volume = 1.0, bool $is_critical = false ) {
-		$this->name = $name;
+		$this->name   = $name;
 		$this->volume = $volume;
-		$this->setIsCritical( $is_critical );
+		$this->set_is_critical( $is_critical );
 	}
 
-	public static function fromString( string $name ): APNSSound {
+	public static function from_string( string $name ): APNSSound {
 		return new APNSSound( $name );
 	}
 
-	public function getIsCritical(): bool {
+	public function get_is_critical(): bool {
 		return $this->is_critical;
 	}
 
-	public function setIsCritical( bool $is_critical ): self {
+	public function set_is_critical( bool $is_critical ): self {
 		$this->is_critical = $is_critical;
 		return $this;
 	}
 
-	public function getName(): string {
+	public function get_name(): string {
 		return $this->name;
 	}
 
-	public function setName( string $name ): self {
+	public function set_name( string $name ): self {
 		$this->name = $name;
 		return $this;
 	}
 
-	public function getVolume(): float {
+	public function get_volume(): float {
 		return $this->volume;
 	}
 
-	public function setVolume( float $volume ): self {
+	public function set_volume( float $volume ): self {
 		if ( $volume < 0 || $volume > 1.0 ) {
 			throw new InvalidArgumentException( 'Invalid sound volume: ' . $volume . '. Valid volume levels are between 0.0 and 1.0' );
 		}
@@ -64,8 +64,8 @@ class APNSSound implements JsonSerializable {
 
 		return [
 			'critical' => $this->is_critical ? 1 : 0,
-			'name' => $this->name,
-			'volume' => $this->volume,
+			'name'     => $this->name,
+			'volume'   => $this->volume,
 		];
 	}
 }

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -13,13 +13,13 @@ abstract class APNSTest extends TestCase {
 		$this->assertFalse( property_exists( $object, $key ) );
 	}
 
-	function random_string( $length = 32 ) {
+	protected function random_string( $length = 32 ) {
 		$hex = bin2hex( random_bytes( $length ) );
 		$string = substr( $hex, 0, $length );
 		return $string;
 	}
 
-	function random_uuid() {
+	protected function random_uuid() {
 		return $this->random_string( 8 ) .
 		'-' .
 		$this->random_string( 4 ) .
@@ -32,15 +32,15 @@ abstract class APNSTest extends TestCase {
 	}
 
 	// Fixtures
-	function new_sound(): APNSSound {
+	protected function new_sound(): APNSSound {
 		return new APNSSound( $this->random_string() );
 	}
 
-	function new_alert(): APNSAlert {
+	protected function new_alert(): APNSAlert {
 		return new APNSAlert( $this->random_string(), $this->random_string() );
 	}
 
-	function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ) {
+	protected function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ) {
 
 		if ( is_null( $payload ) ) {
 			$payload = $this->new_payload();
@@ -57,15 +57,15 @@ abstract class APNSTest extends TestCase {
 		return APNSRequest::fromPayload( $payload, $token, $metadata );
 	}
 
-	function new_request_from_token( string $token ): APNSRequest {
+	protected function new_request_from_token( string $token ): APNSRequest {
 		return $this->new_request( null, $token, null );
 	}
 
-	function new_request_from_metadata( APNSRequestMetadata $meta ): APNSRequest {
+	protected function new_request_from_metadata( APNSRequestMetadata $meta ): APNSRequest {
 		return $this->new_request( null, null, $meta );
 	}
 
-	function new_metadata( ?string $topic = null, ?string $uuid = null ): APNSRequestMetadata {
+	protected function new_metadata( ?string $topic = null, ?string $uuid = null ): APNSRequestMetadata {
 
 		if ( is_null( $topic ) ) {
 			$topic = $this->random_string();
@@ -78,11 +78,11 @@ abstract class APNSTest extends TestCase {
 		return new APNSRequestMetadata( $topic, $uuid );
 	}
 
-	function new_payload(): APNSPayload {
+	protected function new_payload(): APNSPayload {
 		return APNSPayload::fromAlert( $this->new_alert() );
 	}
 
-	function new_configuration(): APNSConfiguration {
+	protected function new_configuration(): APNSConfiguration {
 		$factory = Mockery::mock( APNSTokenFactory::class );
 		$factory->allows(
 			[
@@ -93,35 +93,35 @@ abstract class APNSTest extends TestCase {
 		return $this->new_configuration_with_token_factory( $factory );
 	}
 
-	function new_configuration_with_token_factory( APNSTokenFactory $factory ): APNSConfiguration {
+	protected function new_configuration_with_token_factory( APNSTokenFactory $factory ): APNSConfiguration {
 		return APNSConfiguration::production( $this->new_credentials(), $factory );
 	}
 
-	function new_token_factory_with_mocked_token( string $token ): APNSTokenFactory {
+	protected function new_token_factory_with_mocked_token( string $token ): APNSTokenFactory {
 		$factory = Mockery::mock( APNSTokenFactory::class );
 		$factory->shouldReceive( 'get_token' )->andReturn( $token )->once();
 		return $factory;
 	}
 
-	function new_configuration_with_mocked_provider_token( string $token ): APNSConfiguration {
+	protected function new_configuration_with_mocked_provider_token( string $token ): APNSConfiguration {
 		return $this->new_configuration_with_token_factory( $this->new_token_factory_with_mocked_token( $token ) );
 	}
 
-	function new_configuration_with_mocked_endpoint( string $endpoint ): APNSConfiguration {
+	protected function new_configuration_with_mocked_endpoint( string $endpoint ): APNSConfiguration {
 		$factory = Mockery::mock( APNSConfiguration::class );
 		$factory->shouldReceive( 'get_endpoint' )->andReturn( $endpoint )->once();
 		return $factory;
 	}
 
-	function new_sandbox_configuration(): APNSConfiguration {
+	protected function new_sandbox_configuration(): APNSConfiguration {
 		return APNSConfiguration::sandbox( $this->new_credentials() );
 	}
 
-	function new_credentials(): APNSCredentials {
+	protected function new_credentials(): APNSCredentials {
 		return new APNSCredentials( $this->random_string( 10 ), $this->random_string( 10 ), '' );
 	}
 
-	function to_stdclass( $object ): object {
+	protected function to_stdclass( $object ): object {
 		if ( is_a( $object, APNSPayload::class ) ) {
 			return $this->from_json( $object->toJSON() );
 		}
@@ -129,11 +129,11 @@ abstract class APNSTest extends TestCase {
 		return json_decode( json_encode( $object ) );
 	}
 
-	function to_string( $object ): string {
+	protected function to_string( $object ): string {
 		return json_decode( json_encode( $object ) );
 	}
 
-	function new_apns_http_failure_response( int $status_code, string $reason = 'not read here' ): string {
+	protected function new_apns_http_failure_response( int $status_code, string $reason = 'not read here' ): string {
 		return <<<TEXT
 HTTP/2 $status_code
 apns-id: 8FE746FE-1112-2966-3590-2DC3F038536B
@@ -142,27 +142,27 @@ apns-id: 8FE746FE-1112-2966-3590-2DC3F038536B
 TEXT;
 	}
 
-	function from_json( string $string ): object {
+	protected function from_json( string $string ): object {
 		return json_decode( $string );
 	}
 
-	function json_without( string $string, string $key ): string {
+	protected function json_without( string $string, string $key ): string {
 		$object = json_decode( $string );
 		unset( $object->$key );
 		return json_encode( $object );
 	}
 
-	function json_adding( string $string, string $key, $value ): string {
+	protected function json_adding( string $string, string $key, $value ): string {
 		$object = json_decode( $string );
 		$object->$key = $value;
 		return json_encode( $object );
 	}
 
-	function decode( string $string ): object {
+	protected function decode( string $string ): object {
 		return json_decode( $string );
 	}
 
-	function replace_object_key_with_value( $object, $key, $value ) {
+	protected function replace_object_key_with_value( $object, $key, $value ) {
 		$class = new ReflectionClass( get_class( $object ) );
 
 		$property = $class->getProperty( $key );
@@ -172,7 +172,7 @@ TEXT;
 		return $object;
 	}
 
-	function get_test_resource( $key ): string {
+	protected function get_test_resource( $key ): string {
 		return file_get_contents( 'tests/resources/' . $key . '.txt' );
 	}
 }

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -13,13 +13,13 @@ abstract class APNSTest extends TestCase {
 		$this->assertFalse( property_exists( $object, $key ) );
 	}
 
-	protected function random_string( $length = 32 ) {
+	protected function random_string( $length = 32 ): string {
 		$hex = bin2hex( random_bytes( $length ) );
 		$string = substr( $hex, 0, $length );
 		return $string;
 	}
 
-	protected function random_uuid() {
+	protected function random_uuid(): string {
 		return $this->random_string( 8 ) .
 		'-' .
 		$this->random_string( 4 ) .
@@ -40,7 +40,7 @@ abstract class APNSTest extends TestCase {
 		return new APNSAlert( $this->random_string(), $this->random_string() );
 	}
 
-	protected function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ) {
+	protected function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ): APNSRequest {
 
 		if ( is_null( $payload ) ) {
 			$payload = $this->new_payload();
@@ -162,7 +162,7 @@ TEXT;
 		return json_decode( $string );
 	}
 
-	protected function replace_object_key_with_value( $object, $key, $value ) {
+	protected function replace_object_key_with_value( $object, $key, $value ): object {
 		$class = new ReflectionClass( get_class( $object ) );
 
 		$property = $class->getProperty( $key );

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -1,5 +1,8 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
 use PHPUnit\Framework\TestCase;
 
 abstract class APNSTest extends TestCase {
@@ -14,7 +17,7 @@ abstract class APNSTest extends TestCase {
 	}
 
 	protected function random_string( $length = 32 ): string {
-		$hex = bin2hex( random_bytes( $length ) );
+		$hex    = bin2hex( random_bytes( $length ) );
 		$string = substr( $hex, 0, $length );
 		return $string;
 	}
@@ -54,7 +57,7 @@ abstract class APNSTest extends TestCase {
 			$metadata = $this->new_metadata();
 		}
 
-		return APNSRequest::fromPayload( $payload, $token, $metadata );
+		return APNSRequest::from_payload( $payload, $token, $metadata );
 	}
 
 	protected function new_request_from_token( string $token ): APNSRequest {
@@ -79,7 +82,7 @@ abstract class APNSTest extends TestCase {
 	}
 
 	protected function new_payload(): APNSPayload {
-		return APNSPayload::fromAlert( $this->new_alert() );
+		return APNSPayload::from_alert( $this->new_alert() );
 	}
 
 	protected function new_configuration(): APNSConfiguration {
@@ -123,7 +126,7 @@ abstract class APNSTest extends TestCase {
 
 	protected function to_stdclass( $object ): object {
 		if ( is_a( $object, APNSPayload::class ) ) {
-			return $this->from_json( $object->toJSON() );
+			return $this->from_json( $object->to_json() );
 		}
 
 		return json_decode( json_encode( $object ) );
@@ -153,7 +156,7 @@ TEXT;
 	}
 
 	protected function json_adding( string $string, string $key, $value ): string {
-		$object = json_decode( $string );
+		$object       = json_decode( $string );
 		$object->$key = $value;
 		return json_encode( $object );
 	}

--- a/tests/MockAPNSServer/.gitignore
+++ b/tests/MockAPNSServer/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+test-cert.pem
+test-key.pem

--- a/tests/MockAPNSServer/package.json
+++ b/tests/MockAPNSServer/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "prettier": "^2.1.1",
     "uuid": "^8.3.0"
   },
   "scripts": {

--- a/tests/MockAPNSServer/server.js
+++ b/tests/MockAPNSServer/server.js
@@ -1,54 +1,70 @@
-const http2 = require("http2");
-const fs = require("fs");
-const uuid = require("uuid");
+const http2 = require( "http2" );
+const fs    = require( "fs" );
+const uuid  = require( "uuid" );
 
-const server = http2.createSecureServer({
-  key: fs.readFileSync("test-key.pem"),
-  cert: fs.readFileSync("test-cert.pem"),
-});
-server.on("error", (err) => console.error(err));
+const server = http2.createSecureServer(
+	{
+		key: fs.readFileSync( "test-key.pem" ),
+		cert: fs.readFileSync( "test-cert.pem" ),
+	}
+);
+
+server.on(
+	"error",
+	function(err){
+		console.error( err )
+	}
+);
 
 var requestNumber = 0;
-var sessions = [];
+var sessions      = [];
 
-server.on("session", (session) => {
-  sessions.push(session);
-});
+server.on(
+	"session",
+	function (session) {
+		sessions.push( session );
+	}
+);
 
-server.on("stream", (stream, headers) => {
+server.on(
+	"stream",
+	function(stream, headers) {
+		stream.respond(
+			{
+				"content-type": "text/html; charset=utf-8",
+				":status": 200,
+				"apns-id": uuid.v4(),
+			}
+		);
+		if (headers[":path"] === "/") {
+			console.log( "Request:", headers );
+			requestNumber++;
+			stream.end( "Request Count: " + requestNumber );
+		}
+		if (headers[":path"] === "/reset") {
+			console.log( "Resetting Sessions. Current Session Count: " + sessions.length );
 
-  stream.respond({
-    "content-type": "text/html; charset=utf-8",
-    ":status": 200,
-    "apns-id": uuid.v4(),
-  });
+			const sessionsCopy = sessions.filter(
+				function(session) {
+					return session !== stream.session
+				}
+			); // Reset all the other sessions except the one for this request
 
-  if (headers[":path"] === "/") {
-    console.log("Request:", headers);
-    requestNumber++;
-    stream.end("Request Count: " + requestNumber);
-  }
+			sessionsCopy.forEach(
+				function (session) {
+					const reason   = Buffer.from( '{"reason": "Foo"}', "utf8" );
+					const streamId = session.state.lastProcStreamID;
+					if ( ! session.closed) {
+						session.goaway( http2.constants.NGHTTP2_NO_ERROR, streamId, reason );
+					}
+				}
+			);
 
-  if (headers[":path"] === "/reset") {
-    console.log("Resetting Sessions. Current Session Count: " + sessions.length);
+			this.sessions = [stream.session];
+			stream.end( `Reset Complete: Current Sessions Count: ${this.sessions.length}` );
+		}
+	}
+);
 
-    const sessionsCopy = sessions.filter(
-      (session) => session !== stream.session
-    ); // Reset all the other sessions except the one for this request
-
-    sessionsCopy.forEach((session) => {
-      const reason = Buffer.from('{"reason": "Foo"}', "utf8");
-      const streamId = session.state.lastProcStreamID;
-
-      if (!session.closed) {
-        session.goaway(http2.constants.NGHTTP2_NO_ERROR, streamId, reason);
-      }
-    });
-
-    sessions = [stream.session];
-    stream.end(`Reset Complete: Current Sessions Count: ${sessions.length}`);
-  }
-});
-
-server.listen(8443);
+server.listen( 8443 );
 console.log(`Server running at https://127.0.0.1:8443`);

--- a/tests/MockAPNSServer/yarn.lock
+++ b/tests/MockAPNSServer/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-prettier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
-
 uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"

--- a/tests/e2e/APNSNetworkServiceTest.php
+++ b/tests/e2e/APNSNetworkServiceTest.php
@@ -6,12 +6,12 @@ declare( strict_types = 1 );
  */
 class APNSNetworkServiceIntegrationTest extends APNSTest {
 
-	function setUp(): void {
+	public function setUp(): void {
 		// Ensure the server is running before each test
 		$this->assertTrue( $this->reset_mock_server(), "The mock server doesn't appear to be running." );
 	}
 
-	function testThatSendingAfterGoAwayFrameEmitsIsRecoverable() {
+	public function testThatSendingAfterGoAwayFrameEmitsIsRecoverable() {
 
 		$count = random_int( 1, 1000 );
 

--- a/tests/e2e/APNSNetworkServiceTest.php
+++ b/tests/e2e/APNSNetworkServiceTest.php
@@ -1,5 +1,9 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_init
+// phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_setopt
+// phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_exec
+// phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_close
 
 /**
  * @group e2e
@@ -16,28 +20,28 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 		$count = random_int( 1, 1000 );
 
 		$service = ( new APNSNetworkService() )
-			->setCertificateBundlePath( dirname( __DIR__ ) . '/MockAPNSServer/test-cert.pem' )
-			->setPort( 8443 );
+			->set_certificate_bundle_path( dirname( __DIR__ ) . '/MockAPNSServer/test-cert.pem' )
+			->set_port( 8443 );
 
 		for ( $i = 0; $i < $count; $i++ ) {
-			$service->enqueueRequest( 'https://127.0.0.1/', [], '' );
+			$service->enqueue_request( 'https://127.0.0.1/', [], '' );
 		}
 
-		$responses = $service->sendQueuedRequests();
+		$responses = $service->send_queued_requests();
 		$this->assertCount( $count, $responses );
 
 		$this->reset_mock_server();
 
 		for ( $i = 0; $i < $count; $i++ ) {
-			$service->enqueueRequest( 'https://127.0.0.1/', [], '' );
+			$service->enqueue_request( 'https://127.0.0.1/', [], '' );
 		}
 
-		$responses = $service->sendQueuedRequests();
-		$this->assertTrue( $responses[0]->isError() );
-		$this->assertTrue( $responses[0]->shouldRetry() );
+		$responses = $service->send_queued_requests();
+		$this->assertTrue( $responses[0]->is_error() );
+		$this->assertTrue( $responses[0]->should_retry() );
 		$this->assertCount( $count, $responses );
 
-		$service->closeConnection();
+		$service->close_connection();
 	}
 
 	private function reset_mock_server(): bool {
@@ -52,6 +56,6 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 		$result = curl_exec( $ch );
 		curl_close( $ch );
 
-		return $result !== false;
+		return false !== $result;
 	}
 }

--- a/tests/integration/APNSDefaultTokenFactoryTest.php
+++ b/tests/integration/APNSDefaultTokenFactoryTest.php
@@ -2,7 +2,7 @@
 declare( strict_types = 1 );
 class APNSDefaultTokenFactoryTest extends APNSTest {
 
-	function testThatTokenContainsExpectedValues() {
+	public function testThatTokenContainsExpectedValues() {
 		$team_id = $this->random_string( 10 );
 		$key_id = $this->random_string( 10 );
 

--- a/tests/integration/APNSDefaultTokenFactoryTest.php
+++ b/tests/integration/APNSDefaultTokenFactoryTest.php
@@ -1,13 +1,15 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
 class APNSDefaultTokenFactoryTest extends APNSTest {
 
 	public function testThatTokenContainsExpectedValues() {
 		$team_id = $this->random_string( 10 );
-		$key_id = $this->random_string( 10 );
+		$key_id  = $this->random_string( 10 );
 
 		$factory = new APNSDefaultTokenFactory();
-		$token = $factory->get_token( $team_id, $key_id, $this->get_test_resource( 'example-key' ) );
+		$token   = $factory->get_token( $team_id, $key_id, $this->get_test_resource( 'example-key' ) );
 
 		$token = $this->decodeJWT( $token );
 
@@ -37,9 +39,9 @@ class APNSDefaultTokenFactoryTest extends APNSTest {
 		$this->assertNotNull( $body );
 
 		return (object) [
-			'key_id' => $head->kid,
+			'key_id'  => $head->kid,
 			'team_id' => $body->iss,
-			'time' => $body->iat,
+			'time'    => $body->iat,
 		];
 	}
 }

--- a/tests/smoke/APNSClientSmokeTest.php
+++ b/tests/smoke/APNSClientSmokeTest.php
@@ -9,23 +9,23 @@ declare( strict_types = 1 );
 class APNSClientSmokeTest extends APNSTest {
 
 	public function testThatSetPortNumberWorks() {
-		$client = ( new APNSClient( $this->new_configuration() ) )->setPortNumber( random_int( 1, 65535 ) );
+		$client = ( new APNSClient( $this->new_configuration() ) )->set_port_number( random_int( 1, 65535 ) );
 		$this->assertNotNull( $client );
 	}
 
 	public function testThatSetDebugWorks() {
-		$client = ( new APNSClient( $this->new_configuration() ) )->setDebug( true );
+		$client = ( new APNSClient( $this->new_configuration() ) )->set_debug( true );
 		$this->assertNotNull( $client );
 	}
 
 	public function testThatSetCertificateBundlePathWorks() {
-		$client = ( new APNSClient( $this->new_configuration() ) )->setCertificateBundlePath( dirname( __DIR__ ) . '/MockAPNSServer/test-cert.pem' );
+		$client = ( new APNSClient( $this->new_configuration() ) )->set_certificate_bundle_path( dirname( __DIR__ ) . '/MockAPNSServer/test-cert.pem' );
 		$this->assertNotNull( $client );
 	}
 
 	public function testThatSetCertificateBundlePathThrowsForInvalidPath() {
 		$this->expectException( InvalidArgumentException::class );
-		( new APNSClient( $this->new_configuration() ) )->setCertificateBundlePath( $this->random_string() );
+		( new APNSClient( $this->new_configuration() ) )->set_certificate_bundle_path( $this->random_string() );
 	}
 
 	public function testThatCloseWorks() {

--- a/tests/unit/APNSAlertTest.php
+++ b/tests/unit/APNSAlertTest.php
@@ -1,9 +1,11 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+
 class APNSAlertTest extends APNSTest {
 	public function testThatAlertConstructorStoresTitleAndBody() {
 		$title = $this->random_string();
-		$body = $this->random_string();
+		$body  = $this->random_string();
 
 		$alert = new APNSAlert( $title, $body );
 		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
@@ -14,22 +16,22 @@ class APNSAlertTest extends APNSTest {
 		$string = $this->random_string();
 
 		$alert = new APNSAlert( $string );
-		$this->assertEquals( $string, $alert->getTitle() );
+		$this->assertEquals( $string, $alert->get_title() );
 		$this->assertEquals( '"' . $string . '"', json_encode( $alert ) );
 	}
 
 	public function testThatAlertTitleSetterWorksForStrings() {
 		$title = $this->random_string();
-		$alert = $this->new_alert()->setTitle( $title );
+		$alert = $this->new_alert()->set_title( $title );
 		$this->assertEquals( $title, $this->to_stdclass( $alert )->title );
-		$this->assertEquals( $title, $alert->getTitle() );
+		$this->assertEquals( $title, $alert->get_title() );
 	}
 
 	public function testThatAlertBodySetterWorks() {
-		$body = $this->random_string();
-		$alert = $this->new_alert()->setBody( $body );
+		$body  = $this->random_string();
+		$alert = $this->new_alert()->set_body( $body );
 		$this->assertEquals( $body, $this->to_stdclass( $alert )->body );
-		$this->assertEquals( $body, $alert->getBody() );
+		$this->assertEquals( $body, $alert->get_body() );
 	}
 
 	public function testThatLocalizedTitleKeyIsNotPresentByDefault() {
@@ -37,44 +39,44 @@ class APNSAlertTest extends APNSTest {
 	}
 
 	public function testThatLocalizedTitleKeySetterWorks() {
-		$key = $this->random_string();
-		$alert = $this->new_alert()->setLocalizedTitleKey( $key );
+		$key   = $this->random_string();
+		$alert = $this->new_alert()->set_localized_title_key( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'title-loc-key'} );
-		$this->assertEquals( $key, $alert->getLocalizedTitleKey() );
+		$this->assertEquals( $key, $alert->get_localized_title_key() );
 	}
 
 	public function testThatLocalizedTitleArgsSetterWorks() {
-		$args = [ 'foo', 1, 1.25, '1.25', null ];
-		$alert = $this->new_alert()->setLocalizedTitleArgs( $args );
+		$args  = [ 'foo', 1, 1.25, '1.25', null ];
+		$alert = $this->new_alert()->set_localized_title_args( $args );
 		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'title-loc-args'} );
-		$this->assertEquals( $args, $alert->getLocalizedTitleArgs() );
+		$this->assertEquals( $args, $alert->get_localized_title_args() );
 	}
 
 	public function testThatLocalizedActionKeySetterWorks() {
-		$key = $this->random_string();
-		$alert = $this->new_alert()->setLocalizedActionKey( $key );
+		$key   = $this->random_string();
+		$alert = $this->new_alert()->set_localized_action_key( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'action-loc-key'} );
-		$this->assertEquals( $key, $alert->getLocalizedActionKey() );
+		$this->assertEquals( $key, $alert->get_localized_action_key() );
 	}
 
 	public function testThatAlertLocalizedMessageKeySetterWorks() {
-		$key = $this->random_string();
-		$alert = $this->new_alert()->setLocalizedMessageKey( $key );
+		$key   = $this->random_string();
+		$alert = $this->new_alert()->set_localized_message_key( $key );
 		$this->assertEquals( $key, $this->to_stdclass( $alert )->{'loc-key'} );
-		$this->assertEquals( $key, $alert->getLocalizedMessageKey() );
+		$this->assertEquals( $key, $alert->get_localized_message_key() );
 	}
 
 	public function testThatAlertLocalizedMessageArgsSetterWorks() {
-		$args = [ 'foo', 1, 1.25, '1.25', null ];
-		$alert = $this->new_alert()->setLocalizedMessageArgs( $args );
+		$args  = [ 'foo', 1, 1.25, '1.25', null ];
+		$alert = $this->new_alert()->set_localized_message_args( $args );
 		$this->assertEquals( $args, $this->to_stdclass( $alert )->{'loc-args'} );
-		$this->assertEquals( $args, $alert->getLocalizedMessageArgs() );
+		$this->assertEquals( $args, $alert->get_localized_message_args() );
 	}
 
 	public function testThatAlertLaunchImageSetterWorks() {
-		$name = $this->random_string();
-		$alert = $this->new_alert()->setLaunchImage( $name );
+		$name  = $this->random_string();
+		$alert = $this->new_alert()->set_launch_image( $name );
 		$this->assertEquals( $name, $this->to_stdclass( $alert )->{'launch-image'} );
-		$this->assertEquals( $name, $alert->getLaunchImage() );
+		$this->assertEquals( $name, $alert->get_launch_image() );
 	}
 }

--- a/tests/unit/APNSClientTest.php
+++ b/tests/unit/APNSClientTest.php
@@ -6,25 +6,25 @@ class APNSClientTest extends APNSTest {
 	public function testThatRequestsFromNetworkAreProcessed() {
 		$network_service_mock = Mockery::mock( 'APNSNetworkService' );
 		$network_service_mock
-			->shouldReceive( 'enqueueRequest' )
+			->shouldReceive( 'enqueue_request' )
 			->once();
 		$fake_responses = [
 			new APNSResponse( 200, $this->new_apns_http_failure_response( 200 ), new APNSResponseMetrics( 1, 1 ) ),
 			new APNSResponse( 400, $this->new_apns_http_failure_response( 400 ), new APNSResponseMetrics( 1, 1 ) ),
 		];
 		$network_service_mock
-			->shouldReceive( 'sendQueuedRequests' )
+			->shouldReceive( 'send_queued_requests' )
 			->andReturn( $fake_responses );
-		$client = APNSClient::withConfiguration( $this->new_configuration(), $network_service_mock );
+		$client = APNSClient::with_configuration( $this->new_configuration(), $network_service_mock );
 
-		$responses = $client->sendRequests( [ $this->new_request() ] );
+		$responses = $client->send_requests( [ $this->new_request() ] );
 
 		$this->assertEquals( count( $fake_responses ), count( $responses ) );
 		// For the purpose of this test it's enough to verify that the received
 		// requests are mapped to the expected type by means of calling a
 		// method on them. It's then up to the test for the type initialization
 		// to verify the mapping is done correctly.
-		$this->assertEquals( $fake_responses[0]->getStatusCode(), $responses[0]->getStatusCode() );
-		$this->assertEquals( $fake_responses[1]->getStatusCode(), $responses[1]->getStatusCode() );
+		$this->assertEquals( $fake_responses[0]->get_status_code(), $responses[0]->get_status_code() );
+		$this->assertEquals( $fake_responses[1]->get_status_code(), $responses[1]->get_status_code() );
 	}
 }

--- a/tests/unit/APNSConfigurationTest.php
+++ b/tests/unit/APNSConfigurationTest.php
@@ -4,22 +4,22 @@ class APNSConfigurationTest extends APNSTest {
 
 	public function testThatProductionInitializerUsesProductionEnvironment() {
 		$config = APNSConfiguration::production( $this->new_credentials() );
-		$this->assertEquals( $config->getEnvironment(), APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION );
+		$this->assertEquals( $config->get_environment(), APNSConfiguration::APNS_ENVIRONMENT_PRODUCTION );
 	}
 
 	public function testThatProductionEndpointIsCorrect() {
 		$config = APNSConfiguration::production( $this->new_credentials() );
-		$this->assertEquals( $config->getEndpoint(), APNSConfiguration::APNS_ENDPOINT_PRODUCTION );
+		$this->assertEquals( $config->get_endpoint(), APNSConfiguration::APNS_ENDPOINT_PRODUCTION );
 	}
 
 	public function testThatSandboxInitializerUsesSandboxEnvironment() {
 		$config = APNSConfiguration::sandbox( $this->new_credentials() );
-		$this->assertEquals( $config->getEnvironment(), APNSConfiguration::APNS_ENVIRONMENT_SANDBOX );
+		$this->assertEquals( $config->get_environment(), APNSConfiguration::APNS_ENVIRONMENT_SANDBOX );
 	}
 
 	public function testThatSandboxEndpointIsCorrect() {
 		$config = APNSConfiguration::sandbox( $this->new_credentials() );
-		$this->assertEquals( $config->getEndpoint(), APNSConfiguration::APNS_ENDPOINT_SANDBOX );
+		$this->assertEquals( $config->get_endpoint(), APNSConfiguration::APNS_ENDPOINT_SANDBOX );
 	}
 
 	// This should be impossible to hit, but just in case, we'll make sure it works
@@ -27,47 +27,47 @@ class APNSConfigurationTest extends APNSTest {
 		$config = APNSConfiguration::sandbox( $this->new_credentials() );
 		$this->replace_object_key_with_value( $config, 'environment', $this->random_string() );
 		$this->expectException( OutOfBoundsException::class );
-		$config->getEndpoint();
+		$config->get_endpoint();
 	}
 
 	public function testThatUserAgentSetterWorks() {
 		$useragent = $this->random_string();
-		$config = $this->new_configuration()->setUserAgent( $useragent );
-		$this->assertEquals( $useragent, $config->getUserAgent() );
+		$config    = $this->new_configuration()->set_user_agent( $useragent );
+		$this->assertEquals( $useragent, $config->get_user_agent() );
 	}
 
 	public function testThatDefaultRefreshIntervalIs30Minutes() {
-		$this->assertEquals( 1800, $this->new_configuration()->getTokenRefreshInterval() );
+		$this->assertEquals( 1800, $this->new_configuration()->get_token_refresh_interval() );
 	}
 
 	public function testThatRefreshIntervalSetterWorks() {
 		$interval = random_int( 1260, 3540 );
-		$config = $this->new_configuration()->setTokenRefreshInterval( $interval );
-		$this->assertEquals( $interval, $config->getTokenRefreshInterval() );
+		$config   = $this->new_configuration()->set_token_refresh_interval( $interval );
+		$this->assertEquals( $interval, $config->get_token_refresh_interval() );
 	}
 
 	public function testThatRefreshIntervalSetterThrowsForValuesLessThan21Minutes() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_configuration()->setTokenRefreshInterval( 1259 );
+		$this->new_configuration()->set_token_refresh_interval( 1259 );
 	}
 
 	public function testThatRefreshIntervalSetterThrowsForValuesGreaterThan59Minutes() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_configuration()->setTokenRefreshInterval( 3541 );
+		$this->new_configuration()->set_token_refresh_interval( 3541 );
 	}
 
 	public function testThatGetProviderTokenFetchesValidToken() {
-		$token = $this->random_string();
+		$token   = $this->random_string();
 		$factory = $this->new_token_factory_with_mocked_token( $token );
-		$config = APNSConfiguration::sandbox( $this->new_credentials(), $factory );
-		$this->assertEquals( $token, $config->getProviderToken() );
+		$config  = APNSConfiguration::sandbox( $this->new_credentials(), $factory );
+		$this->assertEquals( $token, $config->get_provider_token() );
 	}
 
 	public function testThatGetProviderTokenFetchesCachedToken() {
-		$token = $this->random_string();
+		$token   = $this->random_string();
 		$factory = $this->new_token_factory_with_mocked_token( $token );
-		$config = APNSConfiguration::sandbox( $this->new_credentials(), $factory );
-		$this->assertEquals( $token, $config->getProviderToken() );
-		$this->assertEquals( $token, $config->getProviderToken() );
+		$config  = APNSConfiguration::sandbox( $this->new_credentials(), $factory );
+		$this->assertEquals( $token, $config->get_provider_token() );
+		$this->assertEquals( $token, $config->get_provider_token() );
 	}
 }

--- a/tests/unit/APNSCredentialsTest.php
+++ b/tests/unit/APNSCredentialsTest.php
@@ -3,19 +3,19 @@ declare( strict_types = 1 );
 class APNSCredentialsTest extends APNSTest {
 
 	public function testThatAPNSCredentialInstantiationProperlyStoresValues() {
-		$key_id = $this->random_string( 10 );
-		$team_id = $this->random_string( 10 );
+		$key_id    = $this->random_string( 10 );
+		$team_id   = $this->random_string( 10 );
 		$key_bytes = random_bytes( 32 );
 
 		$credentials = new APNSCredentials( $key_id, $team_id, $key_bytes );
-		$this->assertEquals( $key_id, $credentials->getKeyId() );
-		$this->assertEquals( $team_id, $credentials->getTeamId() );
-		$this->assertEquals( $key_bytes, $credentials->getKeyBytes() );
+		$this->assertEquals( $key_id, $credentials->get_key_id() );
+		$this->assertEquals( $team_id, $credentials->get_team_id() );
+		$this->assertEquals( $key_bytes, $credentials->get_key_bytes() );
 	}
 
 	public function testThatSandboxInitializerThrowsForInvalidKeyId() {
-		$key_id = $this->random_string( 11 );
-		$team_id = $this->random_string( 10 );
+		$key_id    = $this->random_string( 11 );
+		$team_id   = $this->random_string( 10 );
 		$key_bytes = random_bytes( 32 );
 
 		$this->expectException( InvalidArgumentException::class );
@@ -23,8 +23,8 @@ class APNSCredentialsTest extends APNSTest {
 	}
 
 	public function testThatSandboxInitializerThrowsForInvalidTeamId() {
-		$key_id = $this->random_string( 10 );
-		$team_id = $this->random_string( 11 );
+		$key_id    = $this->random_string( 10 );
+		$team_id   = $this->random_string( 11 );
 		$key_bytes = random_bytes( 32 );
 
 		$this->expectException( InvalidArgumentException::class );

--- a/tests/unit/APNSPayloadTest.php
+++ b/tests/unit/APNSPayloadTest.php
@@ -3,34 +3,34 @@ declare( strict_types = 1 );
 class APNSPayloadTest extends APNSTest {
 
 	public function testThatBadgeCountInitializerOnlySetsBadgeCount() {
-		$count = random_int( 0, PHP_INT_MAX );
-		$payload = APNSPayload::fromBadgeCount( $count );
+		$count   = random_int( 0, PHP_INT_MAX );
+		$payload = APNSPayload::from_badge_count( $count );
 		$this->assertEquals( $count, $this->to_stdclass( $payload )->aps->badge );
 		$this->assertEquals( 1, count( get_object_vars( $this->to_stdclass( $payload )->aps ) ) );
 	}
 
 	public function testThatAlertInitializerSetsAlertCorrectly() {
-		$alert = $this->new_alert();
-		$payload = APNSPayload::fromAlert( $alert );
+		$alert   = $this->new_alert();
+		$payload = APNSPayload::from_alert( $alert );
 		$this->assertEquals( $this->to_stdclass( $alert ), $this->to_stdclass( $payload )->aps->alert );
 	}
 
 	public function testThatAlertSetterWorksForAlertObjects() {
-		$alert = $this->new_alert();
-		$payload = $this->new_payload()->setAlert( $alert );
+		$alert   = $this->new_alert();
+		$payload = $this->new_payload()->set_alert( $alert );
 		$this->assertEquals( $this->to_stdclass( $alert ), $this->to_stdclass( $payload )->aps->alert );
 	}
 
 	public function testThatAlertSetterWorksForStrings() {
-		$alert = $this->random_string();
-		$payload = $this->new_payload()->setAlert( $alert );
+		$alert   = $this->random_string();
+		$payload = $this->new_payload()->set_alert( $alert );
 		$this->assertEquals( $alert, $this->to_stdclass( $payload )->aps->alert );
-		$this->assertEquals( $alert, $payload->getAlert()->getTitle() );
+		$this->assertEquals( $alert, $payload->get_alert()->get_title() );
 	}
 
 	public function testThatAlertSetterThrowsForInvalidValues() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_payload()->setAlert( 0 );
+		$this->new_payload()->set_alert( 0 );
 	}
 
 	public function testThatSoundIsNotPresentByDefault() {
@@ -39,22 +39,22 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatSoundSetterWorksForStrings() {
-		$sound = $this->random_string();
-		$payload = $this->new_payload()->setSound( $sound );
+		$sound   = $this->random_string();
+		$payload = $this->new_payload()->set_sound( $sound );
 		$this->assertEquals( $sound, $this->to_stdclass( $payload )->aps->sound );
-		$this->assertEquals( $sound, $payload->getSound()->getName() );
+		$this->assertEquals( $sound, $payload->get_sound()->get_name() );
 	}
 
 	public function testThatSoundSetterWorksForSoundObjects() {
-		$sound = $this->new_sound();
-		$payload = $this->new_payload()->setSound( $sound );
-		$this->assertEquals( $sound->getName(), $this->to_stdclass( $payload )->aps->sound );
-		$this->assertEquals( $sound, $payload->getSound() );
+		$sound   = $this->new_sound();
+		$payload = $this->new_payload()->set_sound( $sound );
+		$this->assertEquals( $sound->get_name(), $this->to_stdclass( $payload )->aps->sound );
+		$this->assertEquals( $sound, $payload->get_sound() );
 	}
 
 	public function testThatSoundSetterThrowsForInvalidValues() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_payload()->setSound( 0 );
+		$this->new_payload()->set_sound( 0 );
 	}
 
 	public function testThatBadgeCountIsNotPresentByDefault() {
@@ -64,9 +64,9 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatBadgeCountSetterWorks() {
 		$badge_count = random_int( 1, 99 );
-		$payload = $this->new_payload()->setBadgeCount( $badge_count );
+		$payload     = $this->new_payload()->set_badge_count( $badge_count );
 		$this->assertEquals( $badge_count, $this->to_stdclass( $payload )->aps->badge );
-		$this->assertEquals( $badge_count, $payload->getBadgeCount() );
+		$this->assertEquals( $badge_count, $payload->get_badge_count() );
 	}
 
 	public function testThatContentAvailableIsNotPresentByDefault() {
@@ -74,13 +74,13 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatSetContentAvailableWorks() {
-		$payload = $this->new_payload()->setContentAvailable( true );
+		$payload = $this->new_payload()->set_content_available( true );
 		$this->assertSame( 1, $this->to_stdclass( $payload )->aps->{'content-available'} );
-		$this->assertTrue( $payload->getIsContentAvailable() );
+		$this->assertTrue( $payload->get_is_content_available() );
 
-		$payload = $payload->setContentAvailable( false );
+		$payload = $payload->set_content_available( false );
 		$this->assertKeyIsNotPresentForObject( 'content-available', $this->to_stdclass( $payload )->aps );
-		$this->assertFalse( $payload->getIsContentAvailable() );
+		$this->assertFalse( $payload->get_is_content_available() );
 	}
 
 	public function testThatMutableContentIsNotPresentByDefault() {
@@ -88,13 +88,13 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatMutableContentSetterWorks() {
-		$payload = $this->new_payload()->setMutableContent( true );
+		$payload = $this->new_payload()->set_mutable_content( true );
 		$this->assertSame( 1, $this->to_stdclass( $payload )->aps->{'mutable-content'} );
-		$this->assertTrue( $payload->getIsMutableContent() );
+		$this->assertTrue( $payload->get_is_mutable_content() );
 
-		$payload = $payload->setMutableContent( false );
+		$payload = $payload->set_mutable_content( false );
 		$this->assertKeyIsNotPresentForObject( 'mutable-content', $payload );
-		$this->assertFalse( $payload->getIsMutableContent() );
+		$this->assertFalse( $payload->get_is_mutable_content() );
 	}
 
 	public function testThatTargetContentIdIsNotPresentByDefault() {
@@ -102,10 +102,10 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatTargetContentIdSetterWorks() {
-		$id = $this->random_string();
-		$payload = $this->new_payload()->setTargetContentId( $id );
+		$id      = $this->random_string();
+		$payload = $this->new_payload()->set_target_content_id( $id );
 		$this->assertEquals( $id, $this->to_stdclass( $payload )->aps->{'target-content-id'} );
-		$this->assertEquals( $id, $payload->getTargetContentId() );
+		$this->assertEquals( $id, $payload->get_target_content_id() );
 	}
 
 	public function testThatCategoryIsNotPresentByDefault() {
@@ -114,9 +114,9 @@ class APNSPayloadTest extends APNSTest {
 
 	public function testThatCategorySetterWorks() {
 		$category = $this->random_string();
-		$payload = $this->new_payload()->setCategory( $category );
+		$payload  = $this->new_payload()->set_category( $category );
 		$this->assertEquals( $category, $this->to_stdclass( $payload )->aps->category );
-		$this->assertEquals( $category, $payload->getCategory() );
+		$this->assertEquals( $category, $payload->get_category() );
 	}
 
 	public function testThatThreadIdIsNotPresentByDefault() {
@@ -124,10 +124,10 @@ class APNSPayloadTest extends APNSTest {
 	}
 
 	public function testThatThreadIdSetterWorks() {
-		$thread = $this->random_string();
-		$payload = $this->new_payload()->setThreadId( $thread );
+		$thread  = $this->random_string();
+		$payload = $this->new_payload()->set_thread_id( $thread );
 		$this->assertEquals( $thread, $this->to_stdclass( $payload )->aps->{'thread-id'} );
-		$this->assertEquals( $thread, $payload->getThreadId() );
+		$this->assertEquals( $thread, $payload->get_thread_id() );
 	}
 
 	// The only key that should be present by default is `aps`
@@ -142,10 +142,10 @@ class APNSPayloadTest extends APNSTest {
 			'foo' => 'bar',
 			'baz' => [ 1.0, 1, '1', 0x1 ],
 		];
-		$payload = $this->new_payload()->setCustomData( $custom_data );
-		$object = $this->to_stdclass( $payload );
+		$payload     = $this->new_payload()->set_custom_data( $custom_data );
+		$object      = $this->to_stdclass( $payload );
 		unset( $object->aps );
 		$this->assertEquals( $custom_data, (array) $object );
-		$this->assertEquals( $custom_data, $payload->getCustomData() );
+		$this->assertEquals( $custom_data, $payload->get_custom_data() );
 	}
 }

--- a/tests/unit/APNSRequestMetadataTest.php
+++ b/tests/unit/APNSRequestMetadataTest.php
@@ -4,204 +4,204 @@ class APNSRequestMetadataTest extends APNSTest {
 
 	public function testThatInitializerStoresTopic() {
 		$topic = $this->random_string();
-		$meta = new APNSRequestMetadata( $topic );
-		$this->assertEquals( $topic, $meta->getTopic() );
+		$meta  = new APNSRequestMetadata( $topic );
+		$this->assertEquals( $topic, $meta->get_topic() );
 	}
 
 	public function testThatConvenienceInitializerStoresTopic() {
 		$topic = $this->random_string();
-		$this->assertEquals( $topic, APNSRequestMetadata::withTopic( $topic )->getTopic() );
+		$this->assertEquals( $topic, APNSRequestMetadata::with_topic( $topic )->get_topic() );
 	}
 
 	public function testThatTopicSetterWorks() {
 		$topic = $this->random_string();
-		$meta = $this->new_metadata()->setTopic( $topic );
-		$this->assertEquals( $topic, $meta->getTopic() );
+		$meta  = $this->new_metadata()->set_topic( $topic );
+		$this->assertEquals( $topic, $meta->get_topic() );
 	}
 
 	public function testThatTopicSetterThrowsForEmptyTopic() {
 		$topic = ' ';
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_metadata()->setTopic( $topic );
+		$this->new_metadata()->set_topic( $topic );
 	}
 
 	public function testThatDefaultPushTypeIsAlert() {
-		$this->assertEquals( APNSPushType::ALERT, $this->new_metadata()->getPushType() );
+		$this->assertEquals( APNSPushType::ALERT, $this->new_metadata()->get_push_type() );
 	}
 
 	public function testThatPushTypeSetterWorks() {
-		$meta = $this->new_metadata()->setPushType( APNSPushType::BACKGROUND );
-		$this->assertEquals( APNSPushType::BACKGROUND, $meta->getPushType() );
+		$meta = $this->new_metadata()->set_push_type( APNSPushType::BACKGROUND );
+		$this->assertEquals( APNSPushType::BACKGROUND, $meta->get_push_type() );
 	}
 
 	public function testThatPushTypeSetterAssertsForInvalidPushType() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_metadata()->setPushType( $this->random_string() );
+		$this->new_metadata()->set_push_type( $this->random_string() );
 	}
 
 	public function testThatDefaultExpirationTimeIsZero() {
-		$this->assertEquals( 0, $this->new_metadata()->getExpirationTimestamp() );
+		$this->assertEquals( 0, $this->new_metadata()->get_expiration_timestamp() );
 	}
 
 	public function testThatExpirationTimestampSetterWorks() {
 		$timestamp = strtotime( 'now' ) + 100;
-		$meta = $this->new_metadata()->setExpirationTimestamp( $timestamp );
-		$this->assertEquals( $timestamp, $meta->getExpirationTimestamp() );
+		$meta      = $this->new_metadata()->set_expiration_timestamp( $timestamp );
+		$this->assertEquals( $timestamp, $meta->get_expiration_timestamp() );
 	}
 
 	public function testThatDefaultPriorityIsImmediate() {
-		$this->assertEquals( APNSPriority::IMMEDIATE, $this->new_metadata()->getPriority() );
+		$this->assertEquals( APNSPriority::IMMEDIATE, $this->new_metadata()->get_priority() );
 	}
 
 	public function testThatSettingLowPriorityWorks() {
-		$meta = $this->new_metadata()->setLowPriority();
-		$this->assertEquals( APNSPriority::THROTTLED, $meta->getPriority() );
+		$meta = $this->new_metadata()->set_low_priority();
+		$this->assertEquals( APNSPriority::THROTTLED, $meta->get_priority() );
 	}
 
 	public function testThatSettingNormalPriorityWorks() {
-		$meta = $this->new_metadata()->setLowPriority()->setNormalPriority();
-		$this->assertEquals( APNSPriority::IMMEDIATE, $meta->getPriority() );
+		$meta = $this->new_metadata()->set_low_priority()->set_normal_priority();
+		$this->assertEquals( APNSPriority::IMMEDIATE, $meta->get_priority() );
 	}
 
 	public function testThatDefaultCollapseIdentifierIsNull() {
-		$this->assertNull( $this->new_metadata()->getCollapseIdentifier() );
+		$this->assertNull( $this->new_metadata()->get_collapse_identifier() );
 	}
 
 	public function testThatCollapseIdentifierSetterWorks() {
 		$identifier = $this->random_string( 64 );
-		$meta = $this->new_metadata()->setCollapseIdentifier( $identifier );
-		$this->assertEquals( $identifier, $meta->getCollapseIdentifier() );
+		$meta       = $this->new_metadata()->set_collapse_identifier( $identifier );
+		$this->assertEquals( $identifier, $meta->get_collapse_identifier() );
 	}
 
 	public function testThatCollapseIdentifierSetterThrowsForInvalidIdentifier() {
 		$identifier = $this->random_string( 65 );
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_metadata()->setCollapseIdentifier( $identifier );
+		$this->new_metadata()->set_collapse_identifier( $identifier );
 	}
 
 	public function testThatUuidSetterWorks() {
 		$uuid = $this->random_uuid();
-		$meta = $this->new_metadata()->setUuid( $uuid );
-		$this->assertEquals( $uuid, $meta->getUuid() );
+		$meta = $this->new_metadata()->set_uuid( $uuid );
+		$this->assertEquals( $uuid, $meta->get_uuid() );
 	}
 
 	public function testThatMetadataSerializationIncludesTopic() {
-		$topic = $this->random_string();
-		$encoded = $this->from_json( $this->new_metadata( $topic )->toJSON() );
+		$topic   = $this->random_string();
+		$encoded = $this->from_json( $this->new_metadata( $topic )->to_json() );
 		$this->assertEquals( $topic, $encoded->topic );
 	}
 
 	public function testThatMetadataSerializationIncludesUuid() {
-		$uuid = $this->random_string();
-		$encoded = $this->from_json( $this->new_metadata( $this->random_string(), $uuid )->toJSON() );
+		$uuid    = $this->random_string();
+		$encoded = $this->from_json( $this->new_metadata( $this->random_string(), $uuid )->to_json() );
 		$this->assertEquals( $uuid, $encoded->uuid );
 	}
 
 	public function testThatMetadataSerializationDoesNotIncludePushTypeByDefault() {
-		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$encoded = $this->from_json( $this->new_metadata()->to_json() );
 		$this->assertFalse( property_exists( $encoded, 'push_type' ) );
 	}
 
 	public function testThatMetadataSerializationIncludesPushTypeIfSpecified() {
 		$push_type = APNSPushType::MDM;
-		$encoded = $this->from_json( $this->new_metadata()->setPushType( $push_type )->toJSON() );
+		$encoded   = $this->from_json( $this->new_metadata()->set_push_type( $push_type )->to_json() );
 		$this->assertEquals( $push_type, $encoded->push_type );
 	}
 
 	public function testThatMetadataSerializationDoesNotIncludeExpirationTimestampByDefault() {
-		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$encoded = $this->from_json( $this->new_metadata()->to_json() );
 		$this->assertFalse( property_exists( $encoded, 'expiration_timestamp' ) );
 	}
 
 	public function testThatMetadataSerializationIncludesExpirationTimestampIfSpecified() {
 		$expires_at = random_int( 1, time() );
-		$encoded = $this->from_json( $this->new_metadata()->setExpirationTimestamp( $expires_at )->toJSON() );
+		$encoded    = $this->from_json( $this->new_metadata()->set_expiration_timestamp( $expires_at )->to_json() );
 		$this->assertEquals( $expires_at, $encoded->expiration_timestamp );
 	}
 
 	public function testThatMetadataSerializationDoesNotIncludePriorityByDefault() {
-		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$encoded = $this->from_json( $this->new_metadata()->to_json() );
 		$this->assertFalse( property_exists( $encoded, 'priority' ) );
 	}
 
 	public function testThatMetadataSerializationIncludesPriorityIfSpecified() {
-		$encoded = $this->from_json( $this->new_metadata()->setLowPriority()->toJSON() );
+		$encoded = $this->from_json( $this->new_metadata()->set_low_priority()->to_json() );
 		$this->assertEquals( APNSPriority::THROTTLED, $encoded->priority );
 	}
 
 	public function testThatMetadataSerializationDoesNotIncludeCollapseIdentifierByDefault() {
-		$encoded = $this->from_json( $this->new_metadata()->toJSON() );
+		$encoded = $this->from_json( $this->new_metadata()->to_json() );
 		$this->assertFalse( property_exists( $encoded, 'collapse_identifier' ) );
 	}
 
 	public function testThatMetadataSerializationIncludesCollapseIdentifierIfSpecified() {
 		$identifier = $this->random_string();
-		$encoded = $this->from_json( $this->new_metadata()->setCollapseIdentifier( $identifier )->toJSON() );
+		$encoded    = $this->from_json( $this->new_metadata()->set_collapse_identifier( $identifier )->to_json() );
 		$this->assertEquals( $identifier, $encoded->collapse_identifier );
 	}
 
 	public function testThatMetadataDeserializationIncludesTopic() {
 		$topic = $this->random_string();
-		$meta = APNSRequestMetadata::fromJSON( $this->new_metadata( $topic )->toJSON() );
-		$this->assertEquals( $topic, $meta->getTopic() );
+		$meta  = APNSRequestMetadata::from_json( $this->new_metadata( $topic )->to_json() );
+		$this->assertEquals( $topic, $meta->get_topic() );
 	}
 
 	public function testThatMetadataDeserializationIncludesUuid() {
 		$uuid = $this->random_uuid();
-		$meta = APNSRequestMetadata::fromJSON( $this->new_metadata( null, $uuid )->toJSON() );
-		$this->assertEquals( $uuid, $meta->getUuid() );
+		$meta = APNSRequestMetadata::from_json( $this->new_metadata( null, $uuid )->to_json() );
+		$this->assertEquals( $uuid, $meta->get_uuid() );
 	}
 
 	public function testThatMetadataDeserializationThrowsForMissingTopic() {
-		$json = $this->json_without( $this->new_metadata()->toJSON(), 'topic' );
+		$json = $this->json_without( $this->new_metadata()->to_json(), 'topic' );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequestMetadata::fromJSON( $json );
+		APNSRequestMetadata::from_json( $json );
 	}
 
 	public function testThatMetadataDeserializationThrowsForMissingUuid() {
-		$json = $this->json_without( $this->new_metadata()->toJSON(), 'uuid' );
+		$json = $this->json_without( $this->new_metadata()->to_json(), 'uuid' );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequestMetadata::fromJSON( $json );
+		APNSRequestMetadata::from_json( $json );
 	}
 
 	public function testThatMetadataDeserializationIncludesPushTypeIfPresent() {
 		$push_type = APNSPushType::MDM;
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'push_type', $push_type );
-		$meta = APNSRequestMetadata::fromJSON( $json );
-		$this->assertEquals( $push_type, $meta->getPushType() );
+		$json      = $this->json_adding( $this->new_metadata()->to_json(), 'push_type', $push_type );
+		$meta      = APNSRequestMetadata::from_json( $json );
+		$this->assertEquals( $push_type, $meta->get_push_type() );
 	}
 
 	public function testThatMetadataDeserializationIncludesExpirationTimestampIfPresent() {
 		$expiration_timestamp = time();
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'expiration_timestamp', $expiration_timestamp );
-		$meta = APNSRequestMetadata::fromJSON( $json );
-		$this->assertEquals( $expiration_timestamp, $meta->getExpirationTimestamp() );
+		$json                 = $this->json_adding( $this->new_metadata()->to_json(), 'expiration_timestamp', $expiration_timestamp );
+		$meta                 = APNSRequestMetadata::from_json( $json );
+		$this->assertEquals( $expiration_timestamp, $meta->get_expiration_timestamp() );
 	}
 
 	public function testThatMetadataDeserializationIncludesLowPriorityIfPresent() {
 		$priority = APNSPriority::THROTTLED;
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', $priority );
-		$meta = APNSRequestMetadata::fromJSON( $json );
-		$this->assertEquals( $priority, $meta->getPriority() );
+		$json     = $this->json_adding( $this->new_metadata()->to_json(), 'priority', $priority );
+		$meta     = APNSRequestMetadata::from_json( $json );
+		$this->assertEquals( $priority, $meta->get_priority() );
 	}
 
 	public function testThatMetadataDeserializationIncludesNormalPriorityIfPresent() {
 		$priority = APNSPriority::IMMEDIATE;
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', $priority );
-		$meta = APNSRequestMetadata::fromJSON( $json );
-		$this->assertEquals( $priority, $meta->getPriority() );
+		$json     = $this->json_adding( $this->new_metadata()->to_json(), 'priority', $priority );
+		$meta     = APNSRequestMetadata::from_json( $json );
+		$this->assertEquals( $priority, $meta->get_priority() );
 	}
 
 	public function testThatMetadataDeserializationThrowsForInvalidPriority() {
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'priority', 0 );
+		$json = $this->json_adding( $this->new_metadata()->to_json(), 'priority', 0 );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequestMetadata::fromJSON( $json );
+		APNSRequestMetadata::from_json( $json );
 	}
 
 	public function testThatMetadataDeserializationIncludesCollapseIdentifierIfPresent() {
 		$collapse_identifier = $this->random_string();
-		$json = $this->json_adding( $this->new_metadata()->toJSON(), 'collapse_identifier', $collapse_identifier );
-		$meta = APNSRequestMetadata::fromJSON( $json );
-		$this->assertEquals( $collapse_identifier, $meta->getCollapseIdentifier() );
+		$json                = $this->json_adding( $this->new_metadata()->to_json(), 'collapse_identifier', $collapse_identifier );
+		$meta                = APNSRequestMetadata::from_json( $json );
+		$this->assertEquals( $collapse_identifier, $meta->get_collapse_identifier() );
 	}
 }

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -4,54 +4,54 @@ class APNSRequestTest extends APNSTest {
 
 	public function testRequestInstantiationFromString() {
 		$message = $this->random_string();
-		$token = $this->random_string();
+		$token   = $this->random_string();
 
-		$request = APNSRequest::fromString( $message, $token, $this->new_metadata() );
-		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
+		$request = APNSRequest::from_string( $message, $token, $this->new_metadata() );
+		$this->assertEquals( $message, $this->decode( $request->get_body() )->aps->alert );
 	}
 
 	public function testRequestInstantiationFromPayload() {
 		$message = $this->random_string();
-		$token = $this->random_string();
+		$token   = $this->random_string();
 
-		$request = APNSRequest::fromPayload( APNSPayload::fromString( $message ), $token, $this->new_metadata() );
-		$this->assertEquals( $message, $this->decode( $request->getBody() )->aps->alert );
+		$request = APNSRequest::from_payload( APNSPayload::from_string( $message ), $token, $this->new_metadata() );
+		$this->assertEquals( $message, $this->decode( $request->get_body() )->aps->alert );
 	}
 
 	public function testThatGetTokenRetrievesToken() {
 		$message = $this->random_string();
-		$token = $this->random_string();
+		$token   = $this->random_string();
 
-		$request = APNSRequest::fromString( $message, $token, $this->new_metadata() );
-		$this->assertEquals( $token, $request->getToken() );
+		$request = APNSRequest::from_string( $message, $token, $this->new_metadata() );
+		$this->assertEquals( $token, $request->get_token() );
 	}
 
 	public function testThatGetBodyRetrievesJSONEncodedPush() {
 		$push = $this->new_payload();
-		$this->assertEquals( $push->toJSON(), $this->new_request( $push )->getBody() );
+		$this->assertEquals( $push->to_json(), $this->new_request( $push )->get_body() );
 	}
 
 	public function testThatGetUuidRetrievesUuid() {
 		$uuid = $this->random_uuid();
 
-		$request = APNSRequest::fromString( '', '', $this->new_metadata( null, $uuid ) );
-		$this->assertEquals( $uuid, $request->getUuid() );
+		$request = APNSRequest::from_string( '', '', $this->new_metadata( null, $uuid ) );
+		$this->assertEquals( $uuid, $request->get_uuid() );
 	}
 
 	public function testThatGetUrlForTokenRetrievesValidValue() {
-		$token = $this->random_string();
+		$token         = $this->random_string();
 		$configuration = $this->new_sandbox_configuration();
 
 		$req = $this->new_request( $this->new_payload(), $token, $this->new_metadata() );
 
-		$this->assertEquals( APNSConfiguration::APNS_ENDPOINT_SANDBOX . $token, $req->getUrlForConfiguration( $configuration ) );
+		$this->assertEquals( APNSConfiguration::APNS_ENDPOINT_SANDBOX . $token, $req->get_url_for_configuration( $configuration ) );
 	}
 
 	public function testThatHeadersContainsAuthorizationToken() {
-		$token = $this->random_string();
+		$token         = $this->random_string();
 		$configuration = $this->new_configuration_with_mocked_provider_token( $token );
 
-		$headers = $this->new_request( $this->new_payload(), $token, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), $token, $this->new_metadata() )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'authorization', $headers );
 		$this->assertEquals( 'bearer ' . $token, $headers['authorization'] );
@@ -60,28 +60,28 @@ class APNSRequestTest extends APNSTest {
 	public function testThatGetHeadersContainsContentType() {
 		$configuration = $this->new_configuration();
 
-		$headers = $this->new_request( $this->new_payload() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload() )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'content-type', $headers );
 		$this->assertEquals( 'application/json', $headers['content-type'] );
 	}
 
 	public function testThatGetHeadersContainsValidContentLength() {
-		$push = $this->new_payload();
+		$push          = $this->new_payload();
 		$configuration = $this->new_configuration();
 
-		$headers = $this->new_request( $push )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $push )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'content-length', $headers );
-		$this->assertEquals( strlen( $push->toJSON() ), $headers['content-length'] );
+		$this->assertEquals( strlen( $push->to_json() ), $headers['content-length'] );
 	}
 
 	public function testThatGetHeadersContainsAPNSExpiration() {
 		$configuration = $this->new_configuration();
-		$expiration = time() + 60;
-		$meta = $this->new_metadata()->setExpirationTimestamp( $expiration );
+		$expiration    = time() + 60;
+		$meta          = $this->new_metadata()->set_expiration_timestamp( $expiration );
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-expiration', $headers );
 		$this->assertEquals( $expiration, $headers['apns-expiration'] );
@@ -89,10 +89,10 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersContainsAPNSPushType() {
 		$configuration = $this->new_configuration();
-		$push_type = APNSPushType::MDM;
-		$meta = $this->new_metadata()->setPushType( $push_type );
+		$push_type     = APNSPushType::MDM;
+		$meta          = $this->new_metadata()->set_push_type( $push_type );
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-push-type', $headers );
 		$this->assertEquals( $push_type, $headers['apns-push-type'] );
@@ -100,10 +100,10 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersContainsTopic() {
 		$configuration = $this->new_configuration();
-		$topic = $this->random_string();
-		$meta = $this->new_metadata()->setTopic( $topic );
+		$topic         = $this->random_string();
+		$meta          = $this->new_metadata()->set_topic( $topic );
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-topic', $headers );
 		$this->assertEquals( $topic, $headers['apns-topic'] );
@@ -111,14 +111,14 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainUserAgentByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'user-agent', $this->new_request()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'user-agent', $this->new_request()->get_headers_for_configuration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsUserAgentIfSet() {
-		$ua = $this->random_string();
-		$configuration = $this->new_configuration()->setUserAgent( $ua );
+		$ua            = $this->random_string();
+		$configuration = $this->new_configuration()->set_user_agent( $ua );
 
-		$headers = $this->new_request( $this->new_payload(), null, $this->new_metadata() )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $this->new_metadata() )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'user-agent', $headers );
 		$this->assertEquals( $ua, $headers['user-agent'] );
@@ -126,14 +126,14 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainPriorityByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'apns-priority', $this->new_request()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'apns-priority', $this->new_request()->get_headers_for_configuration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsPriorityIfSet() {
 		$configuration = $this->new_configuration();
-		$meta = $this->new_metadata()->setLowPriority();
+		$meta          = $this->new_metadata()->set_low_priority();
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-priority', $headers );
 		$this->assertEquals( 5, $headers['apns-priority'] );
@@ -141,15 +141,15 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersAlwaysContainApnsIdByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayHasKey( 'apns-id', $this->new_request()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayHasKey( 'apns-id', $this->new_request()->get_headers_for_configuration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsApnsIdIfSet() {
 		$configuration = $this->new_configuration();
-		$uuid = $this->random_uuid();
-		$meta = $this->new_metadata()->setUuid( $uuid );
+		$uuid          = $this->random_uuid();
+		$meta          = $this->new_metadata()->set_uuid( $uuid );
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-id', $headers );
 		$this->assertEquals( $uuid, $headers['apns-id'] );
@@ -157,15 +157,15 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatGetHeadersDoesNotContainCollapseIdByDefault() {
 		$configuration = $this->new_configuration();
-		$this->assertArrayNotHasKey( 'apns-collapse-id', $this->new_request()->getHeadersForConfiguration( $configuration ) );
+		$this->assertArrayNotHasKey( 'apns-collapse-id', $this->new_request()->get_headers_for_configuration( $configuration ) );
 	}
 
 	public function testThatGetHeadersContainsCollapseIdIfSet() {
 		$configuration = $this->new_configuration();
-		$id = $this->random_string();
-		$meta = $this->new_metadata()->setCollapseIdentifier( $id );
+		$id            = $this->random_string();
+		$meta          = $this->new_metadata()->set_collapse_identifier( $id );
 
-		$headers = $this->new_request( $this->new_payload(), null, $meta )->getHeadersForConfiguration( $configuration );
+		$headers = $this->new_request( $this->new_payload(), null, $meta )->get_headers_for_configuration( $configuration );
 
 		$this->assertArrayHasKey( 'apns-collapse-id', $headers );
 		$this->assertEquals( $id, $headers['apns-collapse-id'] );
@@ -173,57 +173,57 @@ class APNSRequestTest extends APNSTest {
 
 	public function testThatRequestSerializationIncludesPayload() {
 		$payload = $this->new_payload();
-		$request = $this->decode( $this->new_request( $payload )->toJSON() );
+		$request = $this->decode( $this->new_request( $payload )->to_json() );
 
-		$this->assertEquals( $payload->toJSON(), $request->payload );
+		$this->assertEquals( $payload->to_json(), $request->payload );
 	}
 
 	public function testThatRequestSerializationIncludesMetadata() {
 		$metadata = $this->new_metadata();
-		$request = $this->decode( $this->new_request_from_metadata( $metadata )->toJSON() );
+		$request  = $this->decode( $this->new_request_from_metadata( $metadata )->to_json() );
 
-		$this->assertEquals( $metadata->toJSON(), $request->metadata );
+		$this->assertEquals( $metadata->to_json(), $request->metadata );
 	}
 
 	public function testThatRequestSerializationIncludesToken() {
-		$token = $this->random_string();
+		$token   = $this->random_string();
 		$request = $this->new_request_from_token( $token );
-		$this->assertEquals( $token, $request->getToken() );
+		$this->assertEquals( $token, $request->get_token() );
 	}
 
 	public function testThatRequestDeserializationIncludesPayload() {
 		$payload = $this->new_payload();
-		$request = APNSRequest::fromJSON( $this->new_request( $payload )->toJSON() );
-		$this->assertEquals( $payload->toJSON(), $request->getBody() );
+		$request = APNSRequest::from_json( $this->new_request( $payload )->to_json() );
+		$this->assertEquals( $payload->to_json(), $request->get_body() );
 	}
 
 	public function testThatRequestDeserializationIncludesToken() {
-		$token = $this->random_string();
-		$request = APNSRequest::fromJSON( $this->new_request_from_token( $token )->toJSON() );
-		$this->assertEquals( $token, $request->getToken() );
+		$token   = $this->random_string();
+		$request = APNSRequest::from_json( $this->new_request_from_token( $token )->to_json() );
+		$this->assertEquals( $token, $request->get_token() );
 	}
 
 	public function testThatRequestDeserializationIncludesMetadata() {
-		$meta = $this->new_metadata();
-		$request = APNSRequest::fromJSON( $this->new_request_from_metadata( $meta )->toJSON() );
-		$this->assertEquals( $meta, $request->getMetadata() );
+		$meta    = $this->new_metadata();
+		$request = APNSRequest::from_json( $this->new_request_from_metadata( $meta )->to_json() );
+		$this->assertEquals( $meta, $request->get_metadata() );
 	}
 
 	public function testThatRequestDeserializationThrowsForMissingPayload() {
-		$json = $this->json_without( $this->new_request()->toJSON(), 'payload' );
+		$json = $this->json_without( $this->new_request()->to_json(), 'payload' );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequest::fromJSON( $json );
+		APNSRequest::from_json( $json );
 	}
 
 	public function testThatRequestDeserializationThrowsForMissingToken() {
-		$json = $this->json_without( $this->new_request()->toJSON(), 'token' );
+		$json = $this->json_without( $this->new_request()->to_json(), 'token' );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequest::fromJSON( $json );
+		APNSRequest::from_json( $json );
 	}
 
 	public function testThatRequestDeserializationThrowsForMissingMetadata() {
-		$json = $this->json_without( $this->new_request()->toJSON(), 'metadata' );
+		$json = $this->json_without( $this->new_request()->to_json(), 'metadata' );
 		$this->expectException( InvalidArgumentException::class );
-		APNSRequest::fromJSON( $json );
+		APNSRequest::from_json( $json );
 	}
 }

--- a/tests/unit/APNSResponseTest.php
+++ b/tests/unit/APNSResponseTest.php
@@ -44,7 +44,7 @@ class APNSResponseTest extends APNSTest {
 		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->isServerError() );
 	}
 
-	private function makeAPNSResponseFor( int $status_code ) {
+	private function makeAPNSResponseFor( int $status_code ): APNSResponse {
 		return new APNSResponse(
 			$status_code,
 			$this->new_apns_http_failure_response( $status_code ),

--- a/tests/unit/APNSResponseTest.php
+++ b/tests/unit/APNSResponseTest.php
@@ -3,45 +3,45 @@ declare( strict_types = 1 );
 class APNSResponseTest extends APNSTest {
 
 	public function testThatResponseParserReadsSuccessResponse() {
-		$data = $this->get_test_resource( '200-success-response' );
+		$data     = $this->get_test_resource( '200-success-response' );
 		$response = new APNSResponse( 200, $data, new APNSResponseMetrics() );
 
-		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->getUuid() );
-		$this->assertEquals( 200, $response->getStatusCode() );
-		$this->assertFalse( $response->isError() );
+		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->get_uuid() );
+		$this->assertEquals( 200, $response->get_status_code() );
+		$this->assertFalse( $response->is_error() );
 	}
 
 	public function testThatResponseParserReadsErrorResponse() {
-		$data = $this->get_test_resource( '400-bad-device-token-response' );
+		$data     = $this->get_test_resource( '400-bad-device-token-response' );
 		$response = new APNSResponse( 400, $data, new APNSResponseMetrics() );
 
-		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->getUuid() );
-		$this->assertEquals( 400, $response->getStatusCode() );
-		$this->assertEquals( 'BadDeviceToken', $response->getErrorMessage() );
+		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->get_uuid() );
+		$this->assertEquals( 400, $response->get_status_code() );
+		$this->assertEquals( 'BadDeviceToken', $response->get_error_message() );
 	}
 
 	public function testThatUnrecoverableErrorsAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 400 )->isUnrecoverableError() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 403 )->isUnrecoverableError() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 404 )->isUnrecoverableError() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 405 )->isUnrecoverableError() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->isUnrecoverableError() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 413 )->isUnrecoverableError() );
-		$this->assertFalse( $this->makeAPNSResponseFor( 429 )->isUnrecoverableError() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 400 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 403 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 404 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 405 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 413 )->is_unrecoverable_error() );
+		$this->assertFalse( $this->makeAPNSResponseFor( 429 )->is_unrecoverable_error() );
 	}
 
 	public function testThatUnsubscribeResponseIsCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->shouldUnsubscribeDevice() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->should_unsubscribe_device() );
 	}
 
 	public function testThatRetryableResponsesAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 429 )->shouldRetry() );
-		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->shouldRetry() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 0 )->shouldRetry() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 429 )->should_retry() );
+		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->should_retry() );
+		$this->assertTrue( $this->makeAPNSResponseFor( 0 )->should_retry() );
 	}
 
 	public function testThatServerErrorResponsesAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->isServerError() );
+		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->is_server_error() );
 	}
 
 	private function makeAPNSResponseFor( int $status_code ): APNSResponse {

--- a/tests/unit/APNSSoundTest.php
+++ b/tests/unit/APNSSoundTest.php
@@ -1,68 +1,70 @@
 <?php
 declare( strict_types = 1 );
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+
 class APNSSoundTest extends APNSTest {
 
 	public function testThatInitializationStoresName() {
-		$name = $this->random_string();
+		$name  = $this->random_string();
 		$sound = new APNSSound( $name );
-		$this->assertEquals( $name, $sound->getName() );
+		$this->assertEquals( $name, $sound->get_name() );
 	}
 
 	public function testThatNameSetterWorks() {
-		$name = $this->random_string();
-		$sound = $this->new_sound()->setName( $name );
+		$name  = $this->random_string();
+		$sound = $this->new_sound()->set_name( $name );
 		$this->assertEquals( $name, $this->to_string( $sound ) );
-		$this->assertEquals( $name, $sound->getName() );
+		$this->assertEquals( $name, $sound->get_name() );
 	}
 
 	public function testThatDefaultVolumeIsMax() {
-		$this->assertEquals( 1.0, $this->new_sound()->getVolume() );
+		$this->assertEquals( 1.0, $this->new_sound()->get_volume() );
 	}
 
 	public function testThatVolumeSetterWorks() {
 		$volume = 0.5;
-		$sound = $this->new_sound()->setVolume( $volume );
-		$this->assertEquals( $volume, $sound->getVolume() );
+		$sound  = $this->new_sound()->set_volume( $volume );
+		$this->assertEquals( $volume, $sound->get_volume() );
 	}
 
 	public function testThatVolumeSetterThrowsForNegativeValues() {
 		$volume = -0.1;
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_sound()->setVolume( $volume );
+		$this->new_sound()->set_volume( $volume );
 	}
 
 	public function testThatVolumeSetterThrowsForValuesGreaterThanOne() {
 		$volume = 1.1;
 		$this->expectException( InvalidArgumentException::class );
-		$this->new_sound()->setVolume( $volume );
+		$this->new_sound()->set_volume( $volume );
 	}
 
 	public function testThatDefaultIsCriticalValueIsFalse() {
-		$this->assertFalse( $this->new_sound()->getIsCritical() );
+		$this->assertFalse( $this->new_sound()->get_is_critical() );
 	}
 
 	public function testThatIsCriticalSetterWorks() {
-		$sound = $this->new_sound()->setIsCritical( true );
-		$this->assertTrue( $sound->getIsCritical() );
+		$sound = $this->new_sound()->set_is_critical( true );
+		$this->assertTrue( $sound->get_is_critical() );
 
-		$sound = $this->new_sound()->setIsCritical( false );
-		$this->assertFalse( $sound->getIsCritical() );
+		$sound = $this->new_sound()->set_is_critical( false );
+		$this->assertFalse( $sound->get_is_critical() );
 	}
 
 	public function testThatSerializationForDefaultsReturnsString() {
-		$name = $this->random_string();
-		$sound = APNSSound::fromString( $name );
+		$name  = $this->random_string();
+		$sound = APNSSound::from_string( $name );
 		$this->assertEquals( '"' . $name . '"', json_encode( $sound ) );
 	}
 
 	public function testThatSerializationForCustomVolumeReturnsObject() {
 		$volume = random_int( 0, 9 ) / 10;
-		$sound = $this->new_sound()->setVolume( $volume );
+		$sound  = $this->new_sound()->set_volume( $volume );
 		$this->assertEquals( $volume, $this->to_stdclass( $sound )->volume );
 	}
 
 	public function testThatSerializationForCustomCriticalityReturnsObject() {
-		$sound = $this->new_sound()->setIsCritical( true );
+		$sound = $this->new_sound()->set_is_critical( true );
 		$this->assertEquals( 1, $this->to_stdclass( $sound )->critical );
 	}
 }

--- a/tests/unit/HTTPMessageParserTest.php
+++ b/tests/unit/HTTPMessageParserTest.php
@@ -3,7 +3,7 @@ declare( strict_types = 1 );
 
 class HTTPMessageParserTest extends APNSTest {
 
-	function testThatParserReadsArbitraryResponses() {
+	public function testThatParserReadsArbitraryResponses() {
 		$data = $this->get_test_resource( 'valid-http-1-response' );
 		$parser = new HTTPMessageParser( $data );
 		$this->assertEquals( 'HTTP/1.1', $parser->getHttpVersion() );
@@ -12,7 +12,7 @@ class HTTPMessageParserTest extends APNSTest {
 		$this->assertEquals( 'Hello world!', $parser->getBody() );
 	}
 
-	function testThatParserReadsAPNSErrorResponses() {
+	public function testThatParserReadsAPNSErrorResponses() {
 		$data = $this->get_test_resource( '400-bad-device-token-response' );
 		$parser = new HTTPMessageParser( $data );
 		$this->assertEquals( 'HTTP/2', $parser->getHttpVersion() );
@@ -21,7 +21,7 @@ class HTTPMessageParserTest extends APNSTest {
 		$this->assertEquals( '{"reason":"BadDeviceToken"}', $parser->getBody() );
 	}
 
-	function testThatParserThrowsForMissingHTTPHeader() {
+	public function testThatParserThrowsForMissingHTTPHeader() {
 		$this->expectException( InvalidArgumentException::class );
 		$data = $this->get_test_resource( 'missing-http-header-response' );
 		new HTTPMessageParser( $data );

--- a/tests/unit/HTTPMessageParserTest.php
+++ b/tests/unit/HTTPMessageParserTest.php
@@ -4,21 +4,21 @@ declare( strict_types = 1 );
 class HTTPMessageParserTest extends APNSTest {
 
 	public function testThatParserReadsArbitraryResponses() {
-		$data = $this->get_test_resource( 'valid-http-1-response' );
+		$data   = $this->get_test_resource( 'valid-http-1-response' );
 		$parser = new HTTPMessageParser( $data );
-		$this->assertEquals( 'HTTP/1.1', $parser->getHttpVersion() );
-		$this->assertEquals( 200, $parser->getStatusCode() );
-		$this->assertEquals( 'Sun, 26 Sep 2010 22:04:35 GMT', $parser->getHeader( 'Last-Modified' ) );
-		$this->assertEquals( 'Hello world!', $parser->getBody() );
+		$this->assertEquals( 'HTTP/1.1', $parser->get_http_version() );
+		$this->assertEquals( 200, $parser->get_status_code() );
+		$this->assertEquals( 'Sun, 26 Sep 2010 22:04:35 GMT', $parser->get_header( 'Last-Modified' ) );
+		$this->assertEquals( 'Hello world!', $parser->get_body() );
 	}
 
 	public function testThatParserReadsAPNSErrorResponses() {
-		$data = $this->get_test_resource( '400-bad-device-token-response' );
+		$data   = $this->get_test_resource( '400-bad-device-token-response' );
 		$parser = new HTTPMessageParser( $data );
-		$this->assertEquals( 'HTTP/2', $parser->getHttpVersion() );
-		$this->assertEquals( 400, $parser->getStatusCode() );
-		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $parser->getHeader( 'apns-id' ) );
-		$this->assertEquals( '{"reason":"BadDeviceToken"}', $parser->getBody() );
+		$this->assertEquals( 'HTTP/2', $parser->get_http_version() );
+		$this->assertEquals( 400, $parser->get_status_code() );
+		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $parser->get_header( 'apns-id' ) );
+		$this->assertEquals( '{"reason":"BadDeviceToken"}', $parser->get_body() );
 	}
 
 	public function testThatParserThrowsForMissingHTTPHeader() {


### PR DESCRIPTION
This PR reformats the code base in order to be accepted by the WordPress.com linter.

It makes the following syntactic changes (but no functional changes):
- Uses Yoda conditions for comparison
- Adds visibility specifiers to every method
- Converts all methods to `snake_case`