### PR TITLE
Add support for userdata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "lint": "./vendor/bin/phpcs -s --ignore=tests/MockAPNSServer/node_modules/",
         "fix": "./vendor/bin/phpcbf --ignore=tests/MockAPNSServer/node_modules/",
         "test": "./vendor/bin/phpunit --coverage-clover 'coverage/coverage.xml' --coverage-html 'coverage'",
+        "quicktest": "./vendor/bin/phpunit --coverage-clover 'coverage/coverage.xml' --coverage-html 'coverage' --exclude e2e",
         "e2e": "./vendor/bin/phpunit --coverage-clover 'coverage/coverage.xml' --coverage-html 'coverage' --group e2e",
         "psalm": "./vendor/bin/psalm"
     }

--- a/src/APNSClient.php
+++ b/src/APNSClient.php
@@ -34,7 +34,7 @@ class APNSClient {
 
 			$url     = $request->get_url_for_configuration( $this->configuration );
 			$headers = $request->get_headers_for_configuration( $this->configuration );
-			$this->network_service->enqueue_request( $url, $this->convert_request_headers( $headers ), $request->get_body() );
+			$this->network_service->enqueue_request( $url, $this->convert_request_headers( $headers ), $request->get_body(), $request->get_userdata() );
 		}
 
 		return $this->network_service->send_queued_requests();

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -34,26 +34,26 @@ class APNSRequest {
 	 */
 	private $userdata;
 
-	public static function from_string( string $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ): self {
+	public static function from_string( string $payload, string $token, APNSRequestMetadata $metadata, array $userdata = [] ): self {
 		$payload = APNSPayload::from_string( $payload );
 		return new APNSRequest( $payload->to_json(), $token, $metadata, $userdata );
 	}
 
-	public static function from_payload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ): self {
+	public static function from_payload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata, array $userdata = [] ): self {
 		return new APNSRequest( $payload->to_json(), $token, $metadata, $userdata );
 	}
 
-	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ) {
+	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata, array $userdata = [] ) {
 		$this->body     = $payload;
 		$this->token    = $token;
 		$this->metadata = $metadata;
-		$this->userdata = (object) array_merge(
-			(array) $userdata,
-			[
-				'apns_token' => $token,
-				'apns_uuid'  => $metadata->get_uuid(),
-			]
-		);
+
+		$default_userdata = [
+			'apns_token' => $token,
+			'apns_uuid'  => $metadata->get_uuid(),
+		];
+
+		$this->userdata = array_merge( $userdata, $default_userdata );
 	}
 
 	public function get_token(): string {
@@ -76,7 +76,7 @@ class APNSRequest {
 		return $configuration->get_endpoint() . $this->token;
 	}
 
-	public function get_userdata(): object {
+	public function get_userdata(): array {
 		return $this->userdata;
 	}
 

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -4,28 +4,56 @@ declare( strict_types = 1 );
 
 class APNSRequest {
 
-	// A string representing the request payload
+	/**
+	 * A string representing the request payload
+	 *
+	 * @var string
+	 */
 	private $body;
 
-	// A copy of the request metadata
+	/**
+	 * A copy of the request metadata
+	 *
+	 * @var APNSRequestMetadata
+	 */
 	private $metadata;
 
-	// The device token
+	/**
+	 * A copy of the device token
+	 *
+	 * @var string
+	 */
 	private $token;
 
-	public static function from_string( string $payload, string $token, APNSRequestMetadata $metadata ): self {
+	/**
+	 * Data that should be passed back in `APNSResponse`. By default, it will always contain the following fields:
+	 * - `apns_token`: The provided token – this can be used to delete invalid tokens from your database
+	 * - `apns_uuid`: The request UUID – this can be used to increment a `retry` field or to delete a given request from a backing store
+	 *
+	 * @var object
+	 */
+	private $userdata;
+
+	public static function from_string( string $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ): self {
 		$payload = APNSPayload::from_string( $payload );
-		return new APNSRequest( $payload->to_json(), $token, $metadata );
+		return new APNSRequest( $payload->to_json(), $token, $metadata, $userdata );
 	}
 
-	public static function from_payload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata ): self {
-		return new APNSRequest( $payload->to_json(), $token, $metadata );
+	public static function from_payload( APNSPayload $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ): self {
+		return new APNSRequest( $payload->to_json(), $token, $metadata, $userdata );
 	}
 
-	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata ) {
+	protected function __construct( string $payload, string $token, APNSRequestMetadata $metadata, ?object $userdata = null ) {
 		$this->body     = $payload;
 		$this->token    = $token;
 		$this->metadata = $metadata;
+		$this->userdata = (object) array_merge(
+			(array) $userdata,
+			[
+				'apns_token' => $token,
+				'apns_uuid'  => $metadata->get_uuid(),
+			]
+		);
 	}
 
 	public function get_token(): string {
@@ -46,6 +74,10 @@ class APNSRequest {
 
 	public function get_url_for_configuration( APNSConfiguration $configuration ): string {
 		return $configuration->get_endpoint() . $this->token;
+	}
+
+	public function get_userdata(): object {
+		return $this->userdata;
 	}
 
 	/**

--- a/src/model/APNSRequest.php
+++ b/src/model/APNSRequest.php
@@ -30,7 +30,7 @@ class APNSRequest {
 	 * - `apns_token`: The provided token – this can be used to delete invalid tokens from your database
 	 * - `apns_uuid`: The request UUID – this can be used to increment a `retry` field or to delete a given request from a backing store
 	 *
-	 * @var object
+	 * @var array
 	 */
 	private $userdata;
 

--- a/src/model/APNSResponse.php
+++ b/src/model/APNSResponse.php
@@ -45,11 +45,11 @@ class APNSResponse {
 	 */
 	private $userdata;
 
-	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics, object $userdata ) {
+	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics, array $userdata = [] ) {
 		$this->status_code = $status_code;
 		$this->metrics     = $metrics;
-		$this->uuid        = strval( $userdata->apns_uuid );
-		$this->token       = strval( $userdata->apns_token );
+		$this->uuid        = strval( $userdata['apns_uuid'] );
+		$this->token       = strval( $userdata['apns_token'] );
 		$this->userdata    = $userdata;
 
 		if ( $this->is_error() ) {
@@ -76,6 +76,10 @@ class APNSResponse {
 
 	public function get_status_code(): int {
 		return $this->status_code;
+	}
+
+	public function get_userdata(): array {
+		return $this->userdata;
 	}
 
 	public function is_error(): bool {

--- a/src/model/APNSResponse.php
+++ b/src/model/APNSResponse.php
@@ -41,7 +41,7 @@ class APNSResponse {
 	/**
 	 * The $userdata object that was passed to the original APNSRequest
 	 *
-	 * @var object
+	 * @var array
 	 */
 	private $userdata;
 

--- a/src/model/APNSResponse.php
+++ b/src/model/APNSResponse.php
@@ -3,31 +3,63 @@ declare( strict_types = 1 );
 
 class APNSResponse {
 
-	/** @var string */
+	/**
+	 * The UUID associated with the APNS request
+	 *
+	 * @var string
+	 */
 	private $uuid;
 
-	/** @var int */
+	/**
+	 * The Device Token the APNS request was sent to
+	 *
+	 * @var string
+	 */
+	private $token;
+
+	/**
+	 * The HTTP status code of the response
+	 *
+	 * @var int
+	 */
 	private $status_code;
 
-	/** @var string|null */
+	/**
+	 * The error message returned by the APNS service, if any
+	 *
+	 * @var string|null
+	 */
 	private $error_message;
 
-	/** @var APNSResponseMetrics */
+	/**
+	 * Response metrics for performance monitoring
+	 *
+	 * @var APNSResponseMetrics
+	 */
 	private $metrics;
 
-	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics ) {
+	/**
+	 * The $userdata object that was passed to the original APNSRequest
+	 *
+	 * @var object
+	 */
+	private $userdata;
+
+	public function __construct( int $status_code, string $response_text, APNSResponseMetrics $metrics, object $userdata ) {
 		$this->status_code = $status_code;
 		$this->metrics     = $metrics;
-
-		$parser     = new HTTPMessageParser( $response_text );
-		$this->uuid = $parser->get_header( 'apns-id' ) ?? 'Not Available';
+		$this->uuid        = strval( $userdata->apns_uuid );
+		$this->token       = strval( $userdata->apns_token );
+		$this->userdata    = $userdata;
 
 		if ( $this->is_error() ) {
 			if ( ! empty( $response_text ) ) {
-				$body = (object) json_decode( $parser->get_body(), false, 512, JSON_THROW_ON_ERROR );
-				/** @var string */
-				$reason              = $body->reason;
-				$this->error_message = $reason;
+				$parser = new HTTPMessageParser( $response_text );
+				$body   = (object) json_decode( $parser->get_body(), false, 512, JSON_THROW_ON_ERROR );
+
+				if ( isset( $body->reason ) && is_string( $body->reason ) ) {
+					$this->error_message = $body->reason;
+				}
 			} else {
 				$this->error_message = '';
 			}
@@ -36,6 +68,10 @@ class APNSResponse {
 
 	public function get_uuid(): string {
 		return $this->uuid;
+	}
+
+	public function get_token(): string {
+		return $this->token;
 	}
 
 	public function get_status_code(): int {

--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -91,7 +91,7 @@ class APNSNetworkService {
 		return $this;
 	}
 
-	public function enqueue_request( string $url, array $headers, string $body, object $userdata ): void {
+	public function enqueue_request( string $url, array $headers, string $body, array $userdata ): void {
 		$ch = curl_init( $url );
 		curl_setopt( $ch, CURLOPT_HEADER, true );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
@@ -169,7 +169,7 @@ class APNSNetworkService {
 
 		$metrics  = new APNSResponseMetrics( $total_bytes, $transfer_time );
 		$raw_data = strval( curl_getinfo( $handle, CURLINFO_PRIVATE ) );
-		$userdata = (object) json_decode( $raw_data );
+		$userdata = (array) json_decode( $raw_data );
 
 		return new APNSResponse( $status_code, $response_text, $metrics, $userdata );
 	}

--- a/src/networking/APNSNetworkService.php
+++ b/src/networking/APNSNetworkService.php
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 // phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_multi_strerror
 // phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_getinfo
 // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+// phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
 class APNSNetworkService {
 
@@ -90,7 +91,7 @@ class APNSNetworkService {
 		return $this;
 	}
 
-	public function enqueue_request( string $url, array $headers, string $body ): void {
+	public function enqueue_request( string $url, array $headers, string $body, object $userdata ): void {
 		$ch = curl_init( $url );
 		curl_setopt( $ch, CURLOPT_HEADER, true );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
@@ -101,6 +102,7 @@ class APNSNetworkService {
 		curl_setopt( $ch, CURLOPT_VERBOSE, $this->debug );
 		curl_setopt( $ch, CURLOPT_PORT, $this->port );
 		curl_setopt( $ch, CURLOPT_TIMEOUT, $this->timeout );
+		curl_setopt( $ch, CURLOPT_PRIVATE, json_encode( $userdata ) );
 
 		if ( ! is_null( $this->certificate_bundle_path ) ) {
 			curl_setopt( $ch, CURLOPT_CAINFO, $this->certificate_bundle_path );
@@ -165,9 +167,11 @@ class APNSNetworkService {
 		$transfer_time = intval( curl_getinfo( $handle, CURLINFO_TOTAL_TIME_T ) ); // as microseconds
 		$total_bytes   = intval( curl_getinfo( $handle, CURLINFO_SIZE_UPLOAD_T ) );
 
-		$metrics = new APNSResponseMetrics( $total_bytes, $transfer_time );
+		$metrics  = new APNSResponseMetrics( $total_bytes, $transfer_time );
+		$raw_data = strval( curl_getinfo( $handle, CURLINFO_PRIVATE ) );
+		$userdata = (object) json_decode( $raw_data );
 
-		return new APNSResponse( $status_code, $response_text, $metrics );
+		return new APNSResponse( $status_code, $response_text, $metrics, $userdata );
 	}
 
 	public function close_connection(): void {

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -43,7 +43,7 @@ abstract class APNSTest extends TestCase {
 		return new APNSAlert( $this->random_string(), $this->random_string() );
 	}
 
-	protected function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null ): APNSRequest {
+	protected function new_request( $payload = null, string $token = null, ?APNSRequestMetadata $metadata = null, ?object $userdata = null ): APNSRequest {
 
 		if ( is_null( $payload ) ) {
 			$payload = $this->new_payload();
@@ -57,7 +57,11 @@ abstract class APNSTest extends TestCase {
 			$metadata = $this->new_metadata();
 		}
 
-		return APNSRequest::from_payload( $payload, $token, $metadata );
+		if ( is_null( $userdata ) ) {
+			$userdata = $this->new_userdata();
+		}
+
+		return APNSRequest::from_payload( $payload, $token, $metadata, $userdata );
 	}
 
 	protected function new_request_from_token( string $token ): APNSRequest {
@@ -122,6 +126,30 @@ abstract class APNSTest extends TestCase {
 
 	protected function new_credentials(): APNSCredentials {
 		return new APNSCredentials( $this->random_string( 10 ), $this->random_string( 10 ), '' );
+	}
+
+	protected function new_apns_response( int $status_code ): APNSResponse {
+		return new APNSResponse(
+			$status_code,
+			$this->new_apns_http_failure_response( $status_code ),
+			new APNSResponseMetrics(),
+			$this->new_userdata(),
+		);
+	}
+
+	protected function new_userdata( ?string $uuid = null, ?string $token = null ): object {
+		return (object) [
+			'apns_uuid'  => $uuid ?? $this->random_uuid(),
+			'apns_token' => $token ?? $this->random_uuid(),
+		];
+	}
+
+	protected function new_userdata_with_uuid( string $uuid ): object {
+		return $this->new_userdata( $uuid, null );
+	}
+
+	protected function new_userdata_with_token( string $token ) {
+		return $this->new_userdata( null, $token );
 	}
 
 	protected function to_stdclass( $object ): object {

--- a/tests/APNSTest.php
+++ b/tests/APNSTest.php
@@ -137,18 +137,18 @@ abstract class APNSTest extends TestCase {
 		);
 	}
 
-	protected function new_userdata( ?string $uuid = null, ?string $token = null ): object {
-		return (object) [
+	protected function new_userdata( ?string $uuid = null, ?string $token = null ): array {
+		return [
 			'apns_uuid'  => $uuid ?? $this->random_uuid(),
 			'apns_token' => $token ?? $this->random_uuid(),
 		];
 	}
 
-	protected function new_userdata_with_uuid( string $uuid ): object {
+	protected function new_userdata_with_uuid( string $uuid ): array {
 		return $this->new_userdata( $uuid, null );
 	}
 
-	protected function new_userdata_with_token( string $token ) {
+	protected function new_userdata_with_token( string $token ): array {
 		return $this->new_userdata( null, $token );
 	}
 

--- a/tests/e2e/APNSNetworkServiceTest.php
+++ b/tests/e2e/APNSNetworkServiceTest.php
@@ -24,7 +24,7 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 			->set_port( 8443 );
 
 		for ( $i = 0; $i < $count; $i++ ) {
-			$service->enqueue_request( 'https://127.0.0.1/', [], '' );
+			$service->enqueue_request( 'https://127.0.0.1/', [], '', $this->new_userdata() );
 		}
 
 		$responses = $service->send_queued_requests();
@@ -33,7 +33,7 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 		$this->reset_mock_server();
 
 		for ( $i = 0; $i < $count; $i++ ) {
-			$service->enqueue_request( 'https://127.0.0.1/', [], '' );
+			$service->enqueue_request( 'https://127.0.0.1/', [], '', $this->new_userdata() );
 		}
 
 		$responses = $service->send_queued_requests();
@@ -51,10 +51,10 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 			->set_port( 8443 )
 			->set_timeout( 1 );
 
-		$service->enqueue_request( 'https://127.0.0.1/', [], '' );
+		$service->enqueue_request( 'https://127.0.0.1/', [], '', $this->new_userdata() );
 		// It's easier to test a remote server here rather than make node work how we want
-		$service->enqueue_request( 'https://httpbin.org/delay/10', [], '' );
-		$service->enqueue_request( 'https://127.0.0.1/', [], '' );
+		$service->enqueue_request( 'https://httpbin.org/delay/10', [], '', $this->new_userdata() );
+		$service->enqueue_request( 'https://127.0.0.1/', [], '', $this->new_userdata() );
 
 		$responses = $service->send_queued_requests();
 
@@ -73,6 +73,21 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 		$this->assertCount( 3, $responses );
 		$this->assertCount( 2, $success );
 		$this->assertCount( 1, $failure );
+
+		$service->close_connection();
+	}
+
+	public function testThatUserDataIsPassedThroughNetworkService() {
+
+		$userdata = $this->new_userdata();
+
+		$service = ( new APNSNetworkService() )->set_port( 8000 );
+		$service->enqueue_request( 'https://httpbin.org/status/200', [], '', $userdata );
+		$responses = $service->send_queued_requests();
+
+		$this->assertCount( 1, $responses );
+		$this->assertEquals( $userdata->apns_uuid, $responses[0]->get_uuid() );
+		$this->assertEquals( $userdata->apns_token, $responses[0]->get_token() );
 
 		$service->close_connection();
 	}

--- a/tests/e2e/APNSNetworkServiceTest.php
+++ b/tests/e2e/APNSNetworkServiceTest.php
@@ -86,8 +86,8 @@ class APNSNetworkServiceIntegrationTest extends APNSTest {
 		$responses = $service->send_queued_requests();
 
 		$this->assertCount( 1, $responses );
-		$this->assertEquals( $userdata->apns_uuid, $responses[0]->get_uuid() );
-		$this->assertEquals( $userdata->apns_token, $responses[0]->get_token() );
+		$this->assertEquals( $userdata['apns_uuid'], $responses[0]->get_uuid() );
+		$this->assertEquals( $userdata['apns_token'], $responses[0]->get_token() );
 
 		$service->close_connection();
 	}

--- a/tests/unit/APNSClientTest.php
+++ b/tests/unit/APNSClientTest.php
@@ -9,8 +9,8 @@ class APNSClientTest extends APNSTest {
 			->shouldReceive( 'enqueue_request' )
 			->once();
 		$fake_responses = [
-			new APNSResponse( 200, $this->new_apns_http_failure_response( 200 ), new APNSResponseMetrics( 1, 1 ) ),
-			new APNSResponse( 400, $this->new_apns_http_failure_response( 400 ), new APNSResponseMetrics( 1, 1 ) ),
+			new APNSResponse( 200, $this->new_apns_http_failure_response( 200 ), new APNSResponseMetrics( 1, 1 ), $this->new_userdata() ),
+			new APNSResponse( 400, $this->new_apns_http_failure_response( 400 ), new APNSResponseMetrics( 1, 1 ), $this->new_userdata() ),
 		];
 		$network_service_mock
 			->shouldReceive( 'send_queued_requests' )

--- a/tests/unit/APNSRequestTest.php
+++ b/tests/unit/APNSRequestTest.php
@@ -18,6 +18,23 @@ class APNSRequestTest extends APNSTest {
 		$this->assertEquals( $message, $this->decode( $request->get_body() )->aps->alert );
 	}
 
+	public function testThatUuidCannotBeOverwrittenWithCustomUserData() {
+		$valid_uuid = $this->random_uuid();
+		$metadata   = $this->new_metadata( 'topic', $valid_uuid );
+
+		$request = APNSRequest::from_string( '', '', $metadata, $this->new_userdata_with_uuid( $this->random_uuid() ) );
+
+		$this->assertEquals( $valid_uuid, $request->get_uuid() );
+	}
+
+	public function testThatTokenCannotBeOverwrittenWithCustomUserData() {
+		$valid_token = $this->random_uuid();
+
+		$request = APNSRequest::from_string( 'message', $valid_token, $this->new_metadata(), $this->new_userdata_with_token( $this->random_uuid() ) );
+
+		$this->assertEquals( $valid_token, $request->get_token() );
+	}
+
 	public function testThatGetTokenRetrievesToken() {
 		$message = $this->random_string();
 		$token   = $this->random_string();

--- a/tests/unit/APNSResponseTest.php
+++ b/tests/unit/APNSResponseTest.php
@@ -30,6 +30,15 @@ class APNSResponseTest extends APNSTest {
 		$this->assertEquals( $expected_token, $response->get_token() );
 	}
 
+	public function testThatResponseProvidesUserData() {
+		$key   = $this->random_string();
+		$value = $this->random_string();
+
+		$response = new APNSResponse( 400, '', new APNSResponseMetrics(), array_merge( $this->new_userdata(), [ $key => $value ] ) );
+
+		$this->assertEquals( $value, $response->get_userdata()[ $key ] );
+	}
+
 	public function testThatUnrecoverableErrorsAreCorrectlyRecognized() {
 		$this->assertTrue( $this->new_apns_response( 400 )->is_unrecoverable_error() );
 		$this->assertTrue( $this->new_apns_response( 403 )->is_unrecoverable_error() );

--- a/tests/unit/APNSResponseTest.php
+++ b/tests/unit/APNSResponseTest.php
@@ -4,51 +4,53 @@ class APNSResponseTest extends APNSTest {
 
 	public function testThatResponseParserReadsSuccessResponse() {
 		$data     = $this->get_test_resource( '200-success-response' );
-		$response = new APNSResponse( 200, $data, new APNSResponseMetrics() );
+		$response = new APNSResponse( 200, $data, new APNSResponseMetrics(), $this->new_userdata() );
 
-		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->get_uuid() );
 		$this->assertEquals( 200, $response->get_status_code() );
 		$this->assertFalse( $response->is_error() );
 	}
 
 	public function testThatResponseParserReadsErrorResponse() {
 		$data     = $this->get_test_resource( '400-bad-device-token-response' );
-		$response = new APNSResponse( 400, $data, new APNSResponseMetrics() );
+		$response = new APNSResponse( 400, $data, new APNSResponseMetrics(), $this->new_userdata() );
 
-		$this->assertEquals( '8FE746FE-1112-2966-3590-2DC3F038536B', $response->get_uuid() );
 		$this->assertEquals( 400, $response->get_status_code() );
 		$this->assertEquals( 'BadDeviceToken', $response->get_error_message() );
 	}
 
+	public function testThatResponseReadsUuidFromUserData() {
+		$expected_uuid = $this->random_uuid();
+		$response      = new APNSResponse( 400, '', new APNSResponseMetrics(), $this->new_userdata_with_uuid( $expected_uuid ) );
+		$this->assertEquals( $expected_uuid, $response->get_uuid() );
+	}
+
+	public function testThatResponseReadsTokenFromUserData() {
+		$expected_token = $this->random_uuid();
+		$response       = new APNSResponse( 400, '', new APNSResponseMetrics(), $this->new_userdata_with_token( $expected_token ) );
+		$this->assertEquals( $expected_token, $response->get_token() );
+	}
+
 	public function testThatUnrecoverableErrorsAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 400 )->is_unrecoverable_error() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 403 )->is_unrecoverable_error() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 404 )->is_unrecoverable_error() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 405 )->is_unrecoverable_error() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->is_unrecoverable_error() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 413 )->is_unrecoverable_error() );
-		$this->assertFalse( $this->makeAPNSResponseFor( 429 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 400 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 403 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 404 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 405 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 410 )->is_unrecoverable_error() );
+		$this->assertTrue( $this->new_apns_response( 413 )->is_unrecoverable_error() );
+		$this->assertFalse( $this->new_apns_response( 429 )->is_unrecoverable_error() );
 	}
 
 	public function testThatUnsubscribeResponseIsCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 410 )->should_unsubscribe_device() );
+		$this->assertTrue( $this->new_apns_response( 410 )->should_unsubscribe_device() );
 	}
 
 	public function testThatRetryableResponsesAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( 429 )->should_retry() );
-		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->should_retry() );
-		$this->assertTrue( $this->makeAPNSResponseFor( 0 )->should_retry() );
+		$this->assertTrue( $this->new_apns_response( 429 )->should_retry() );
+		$this->assertTrue( $this->new_apns_response( random_int( 500, 599 ) )->should_retry() );
+		$this->assertTrue( $this->new_apns_response( 0 )->should_retry() );
 	}
 
 	public function testThatServerErrorResponsesAreCorrectlyRecognized() {
-		$this->assertTrue( $this->makeAPNSResponseFor( random_int( 500, 599 ) )->is_server_error() );
-	}
-
-	private function makeAPNSResponseFor( int $status_code ): APNSResponse {
-		return new APNSResponse(
-			$status_code,
-			$this->new_apns_http_failure_response( $status_code ),
-			new APNSResponseMetrics()
-		);
+		$this->assertTrue( $this->new_apns_response( random_int( 500, 599 ) )->is_server_error() );
 	}
 }

--- a/tests/unit/HTTPMessageParserTest.php
+++ b/tests/unit/HTTPMessageParserTest.php
@@ -26,4 +26,20 @@ class HTTPMessageParserTest extends APNSTest {
 		$data = $this->get_test_resource( 'missing-http-header-response' );
 		new HTTPMessageParser( $data );
 	}
+
+	public function testThatParserReturnsHttp2ForEmptyHttpResponse() {
+		$this->assertSame( '2.0', ( new HTTPMessageParser( '' ) )->get_http_version() );
+	}
+
+	public function testThatParserReturnsZeroStatusCodeForEmptyHttpResponse() {
+		$this->assertSame( 0, ( new HTTPMessageParser( '' ) )->get_status_code() );
+	}
+
+	public function testThatParserReturnsEmptyBodyForEmptyHttpResponse() {
+		$this->assertSame( '', ( new HTTPMessageParser( '' ) )->get_body() );
+	}
+
+	public function testThatParserReturnsNullAPNSIdHeaderForEmptyHttpResponse() {
+		$this->assertNull( ( new HTTPMessageParser( '' ) )->get_header( 'apns-id' ) );
+	}
 }


### PR DESCRIPTION
Adds support for passing a `$userdata` object into an `APNSRequest`, which the network layer will ensure is passed to the corresponding `APNSResponse` object. By default, the object will always contain the `apns_uuid` and `apns_token` fields, which are useful for associating the response with a given notification or device token. If instead of a UUID the developer is using an integer-based primary key, they can pass their own key in `$userdata` that allows for later retrieval.

**To Test:**
- The tests in this PR should be sufficient